### PR TITLE
[DEV] Custom operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Simply use pip to install the package:
 pip install "caterpillar[all]@git+https://github.com/MatrixEditor/caterpillar.git"
 ```
 
+> [!NOTE]
+> You will need to install `make`, a C compiler and the Python3.12 development package.
+
 ## Starting Point
 
 Please visit the [Documentation](https://matrixeditor.github.io/caterpillar/), it contains a complete tutorial on how to use this library.

--- a/docs/sphinx/source/tutorial/advanced.rst
+++ b/docs/sphinx/source/tutorial/advanced.rst
@@ -81,6 +81,26 @@ structs. They have to be wrapped by a :class:`~caterpillar.fields.Field` first:
     >>> field = F(Format) @ 0x1234  # ok
 
 
+Custom Operators
+^^^^^^^^^^^^^^^^
+
+In addition to standard Python operators it is possible to define new operators
+tailored to specific use-cases. For instance, it is possible to define a
+new operator that automatically creates an Array with a fixed length:
+
+.. code-block:: python
+
+    from caterpillar.fields import _infix_
+
+    M = _infix_(lambda s, count: s[count * 2])
+
+    @struct
+    class Format:
+        values: uint16 /M/ 3
+
+As of now, the operator is used only during pre-processing. It won't affect the
+overall parsing process on its own but can be used to return custom structs.
+
 Pointers
 ^^^^^^^^
 

--- a/examples/operator_example.py
+++ b/examples/operator_example.py
@@ -1,0 +1,21 @@
+from caterpillar.model import struct, sizeof
+from caterpillar.fields import uint16, _infix_
+from caterpillar.options import S_REPLACE_TYPES
+
+# Here, we define a custom operator named 'M' that will multiply
+# the second argument by 2.
+M = _infix_(lambda a, b: a[b*2])
+
+# or directly as function
+# @_infix_
+# def M(a, b):
+#     return a[b*2]
+
+@struct(options={S_REPLACE_TYPES})
+class Format:
+    # __annotations__ should contain typing.List[int] as we've specified the
+    # documentation option.
+    f1: uint16 /M/ 3
+
+print(Format.__annotations__)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ wheel.py-api = "cp312"
 
 [project]
 name = "caterpillar"
-version = "2.0.0-b0"
+version = "2.0.1"
 
 description="Library to pack and unpack structurized binary data."
 authors = [

--- a/src/caterpillar/__init__.py
+++ b/src/caterpillar/__init__.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = "2.0.0-b2"
+__version__ = "2.0.1"
 __release__ = None
 __author__ = "MatrixEditor"
 

--- a/src/caterpillar/fields/__init__.py
+++ b/src/caterpillar/fields/__init__.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from ._base import Field, INVALID_DEFAULT, DEFAULT_OPTION, singleton
-from ._mixin import FieldMixin, FieldStruct, Chain
+from ._mixin import FieldMixin, FieldStruct, Chain, _infix_
 from .common import (
     FormatField,
     Transformer,

--- a/src/caterpillar/fields/common.py
+++ b/src/caterpillar/fields/common.py
@@ -81,14 +81,12 @@ class FormatField(FieldStruct):
 
     def __size__(self, context: _ContextLike) -> int:
         """
-        Calculate the size of the field.
+        Calculate the size of the field (single element).
 
         :param context: The current context.
         :return: The size of the field.
         """
-        order = context[CTX_FIELD].order
-        length = self.get_length(context)
-        return libstruct.calcsize(f"{order.ch}{length}{self.text}")
+        return self.__bits__ // 8
 
     def pack_single(self, obj: Any, context: _ContextLike) -> None:
         """


### PR DESCRIPTION
Version `2.0.1` adds support for user-defined operators and fixes an issue with the `sizeof` calculation of `FormatField`objects.

### Custom Operator (example)
```python3
from caterpillar.model import struct, sizeof
from caterpillar.fields import uint16, _infix_

# operator definition here (@_infix is also possible)
M = _infix_(lambda _s, count: _s[count * 2])

@struct 
class Format:
    values: uint16 /M/ 3
```