### PR TITLE
[NOTE] Unsupported Version: Python3.14 for Digest and conditional fields 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 > This project is still in beta/testing phase. Expect bugs, naming changes and errors while using this
 > library. C API Reference is WIP, C extensions are supported since v2.1.0.
 
+> [!NOTE]
+> Python 3.14 breaks `with` statements in class definitions since `__annotations__` are added at the end
+> of a class definition. Therefore, `Digest` and contiaitonal statements **ARE NOT SUPPORTED** in Python 3.14+.
+
+
+
 Caterpillar is a Python 3.12+ library to pack and unpack structurized binary data. It
 enhances the capabilities of [Python Struct](https://docs.python.org/3/library/struct.html)
 by enabling direct class declaration. More information about the different configuration
@@ -42,6 +48,7 @@ class Format:
     name: String(this.length) #  -> you can also use Prefixed(uint8)
 
     # wraps all following fields and creates a new attr
+    # only for Python <= 3.13
     with Md5(name="hash", verify=True):
         # Sequences with prefixed, computed lengths
         names: CString[uint8::]

--- a/docs/sphinx/source/library/fields/common.rst
+++ b/docs/sphinx/source/library/fields/common.rst
@@ -77,7 +77,7 @@ Bytes, Strings
     :members:
 
     .. versionadded:: 2.4.0
-        Added support for arbitrary structs
+        Added support for arbitrary structs. **Warning: the second parameter is now a struct instead of the encoding string.**
 
 .. autoclass:: caterpillar.py.CString
     :members:

--- a/docs/sphinx/source/library/fields/crypto.rst
+++ b/docs/sphinx/source/library/fields/crypto.rst
@@ -10,11 +10,9 @@ Hashes
 
 .. autoclass:: caterpillar.py.Algorithm
 
-    .. versionadded:: 2.4.0
 
 .. autoclass:: caterpillar.py.Digest
 
-    .. versionadded:: 2.4.0
 
 Ciphers
 -------

--- a/docs/sphinx/source/library/fields/crypto.rst
+++ b/docs/sphinx/source/library/fields/crypto.rst
@@ -10,7 +10,11 @@ Hashes
 
 .. autoclass:: caterpillar.py.Algorithm
 
+    .. versionadded:: 2.4.0
+
 .. autoclass:: caterpillar.py.Digest
+
+    .. versionadded:: 2.4.0
 
 Ciphers
 -------

--- a/docs/sphinx/source/library/model.rst
+++ b/docs/sphinx/source/library/model.rst
@@ -10,6 +10,10 @@ Struct Model
 Base classes
 ------------
 
+.. autoclass:: caterpillar.py.Action
+
+    .. versionadded:: 2.4.0
+
 .. autoclass:: caterpillar.model.Sequence()
     :members:
 

--- a/docs/sphinx/source/tutorial/advanced/actions.rst
+++ b/docs/sphinx/source/tutorial/advanced/actions.rst
@@ -30,6 +30,9 @@ effects that are not tied to the direct data of the struct.
 Advanced Usage: Message Digests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. warning::
+    This feature is not supported in Python 3.14+.
+
 Actions can also be used to perform more complex operations, such as calculating
 checksums or cryptographic hash values before or after processing fields. For
 example, you can use an action to automatically wrap a sequence of fields with a

--- a/docs/sphinx/source/tutorial/advanced/conditional.rst
+++ b/docs/sphinx/source/tutorial/advanced/conditional.rst
@@ -3,6 +3,9 @@
 Conditional Fields
 ==================
 
+.. warning::
+    This feature is not supported in Python 3.14+.
+
 *Conditional fields* allow you to define fields in a struct that are included
 or excluded based on certain conditions. This feature is especially useful when
 working with versioned formats or optional fields that depend on runtime

--- a/examples/formats/caf.py
+++ b/examples/formats/caf.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/examples/formats/itdb.py
+++ b/examples/formats/itdb.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/examples/formats/nibarchive.py
+++ b/examples/formats/nibarchive.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ cmake.source-dir = "."
 
 [project]
 name = "caterpillar"
-version = "2.4.2"
+version = "2.4.3"
 
 description="Library to pack and unpack structurized binary data."
 authors = [

--- a/src/caterpillar/__init__.py
+++ b/src/caterpillar/__init__.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import warnings
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"
 __release__ = None
 __author__ = "MatrixEditor"
 

--- a/src/caterpillar/__init__.py
+++ b/src/caterpillar/__init__.py
@@ -12,6 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import warnings
 
 __version__ = "2.4.2"
 __release__ = None
@@ -27,3 +28,7 @@ def native_support():
         return True
     except ImportError:
         return False
+
+
+# Explicitly report deprecation warnings
+warnings.filterwarnings("default", module="caterpillar")

--- a/src/caterpillar/__init__.py
+++ b/src/caterpillar/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/_common.py
+++ b/src/caterpillar/_common.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/abc.py
+++ b/src/caterpillar/abc.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/byteorder.py
+++ b/src/caterpillar/byteorder.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/context.py
+++ b/src/caterpillar/context.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/context.py
+++ b/src/caterpillar/context.py
@@ -12,6 +12,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 import operator
 import sys
 import warnings

--- a/src/caterpillar/context.py
+++ b/src/caterpillar/context.py
@@ -12,10 +12,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from __future__ import annotations
-
 import operator
 import sys
+import warnings
 
 from typing import Callable, Any, Union, Self
 from types import FrameType
@@ -107,108 +106,108 @@ class ExprMixin:
     A mixin class providing methods for creating binary and unary expressions.
     """
 
-    def __add__(self, other) -> ExprMixin:
+    def __add__(self, other):
         return BinaryExpression(operator.add, self, other)
 
-    def __sub__(self, other) -> ExprMixin:
+    def __sub__(self, other):
         return BinaryExpression(operator.sub, self, other)
 
-    def __mul__(self, other) -> ExprMixin:
+    def __mul__(self, other):
         return BinaryExpression(operator.mul, self, other)
 
-    def __floordiv__(self, other) -> ExprMixin:
+    def __floordiv__(self, other):
         return BinaryExpression(operator.floordiv, self, other)
 
-    def __truediv__(self, other) -> ExprMixin:
+    def __truediv__(self, other):
         return BinaryExpression(operator.truediv, self, other)
 
-    def __mod__(self, other) -> ExprMixin:
+    def __mod__(self, other):
         return BinaryExpression(operator.mod, self, other)
 
-    def __pow__(self, other) -> ExprMixin:
+    def __pow__(self, other):
         return BinaryExpression(operator.pow, self, other)
 
-    def __xor__(self, other) -> ExprMixin:
+    def __xor__(self, other):
         return BinaryExpression(operator.xor, self, other)
 
-    def __and__(self, other) -> ExprMixin:
+    def __and__(self, other):
         return BinaryExpression(operator.and_, self, other)
 
-    def __or__(self, other) -> ExprMixin:
+    def __or__(self, other):
         return BinaryExpression(operator.or_, self, other)
 
-    def __rshift__(self, other) -> ExprMixin:
+    def __rshift__(self, other):
         return BinaryExpression(operator.rshift, self, other)
 
-    def __lshift__(self, other) -> ExprMixin:
+    def __lshift__(self, other):
         return BinaryExpression(operator.lshift, self, other)
 
     __div__ = __truediv__
 
-    def __radd__(self, other) -> ExprMixin:
+    def __radd__(self, other):
         return BinaryExpression(operator.add, other, self)
 
-    def __rsub__(self, other) -> ExprMixin:
+    def __rsub__(self, other):
         return BinaryExpression(operator.sub, other, self)
 
-    def __rmul__(self, other) -> ExprMixin:
+    def __rmul__(self, other):
         return BinaryExpression(operator.mul, other, self)
 
-    def __rfloordiv__(self, other) -> ExprMixin:
+    def __rfloordiv__(self, other):
         return BinaryExpression(operator.floordiv, other, self)
 
-    def __rtruediv__(self, other) -> ExprMixin:
+    def __rtruediv__(self, other):
         return BinaryExpression(operator.truediv, other, self)
 
-    def __rmod__(self, other) -> ExprMixin:
+    def __rmod__(self, other):
         return BinaryExpression(operator.mod, other, self)
 
-    def __rpow__(self, other) -> ExprMixin:
+    def __rpow__(self, other):
         return BinaryExpression(operator.pow, other, self)
 
-    def __rxor__(self, other) -> ExprMixin:
+    def __rxor__(self, other):
         return BinaryExpression(operator.xor, other, self)
 
-    def __rand__(self, other) -> ExprMixin:
+    def __rand__(self, other):
         return BinaryExpression(operator.and_, other, self)
 
-    def __ror__(self, other) -> ExprMixin:
+    def __ror__(self, other):
         return BinaryExpression(operator.or_, other, self)
 
-    def __rrshift__(self, other) -> ExprMixin:
+    def __rrshift__(self, other):
         return BinaryExpression(operator.rshift, other, self)
 
-    def __rlshift__(self, other) -> ExprMixin:
+    def __rlshift__(self, other):
         return BinaryExpression(operator.lshift, other, self)
 
-    def __neg__(self) -> ExprMixin:
+    def __neg__(self):
         return UnaryExpression("neg", operator.neg, self)
 
-    def __pos__(self) -> ExprMixin:
+    def __pos__(self):
         return UnaryExpression("pos", operator.pos, self)
 
-    def __invert__(self) -> ExprMixin:
+    def __invert__(self):
         return UnaryExpression("invert", operator.not_, self)
 
-    def __contains__(self, other) -> ExprMixin:
+    def __contains__(self, other):
         return BinaryExpression(operator.contains, self, other)
 
-    def __gt__(self, other) -> ExprMixin:
+    def __gt__(self, other):
         return BinaryExpression(operator.gt, self, other)
 
-    def __ge__(self, other) -> ExprMixin:
+    def __ge__(self, other):
         return BinaryExpression(operator.ge, self, other)
 
-    def __lt__(self, other) -> ExprMixin:
+    def __lt__(self, other):
         return BinaryExpression(operator.lt, self, other)
 
-    def __le__(self, other) -> ExprMixin:
+    def __le__(self, other):
         return BinaryExpression(operator.le, self, other)
 
-    def __eq__(self, other) -> ExprMixin:
+    def __eq__(self, other):
         return BinaryExpression(operator.eq, self, other)
 
-    def __ne__(self, other) -> ExprMixin:
+    def __ne__(self, other):
         return BinaryExpression(operator.ne, self, other)
 
 
@@ -239,6 +238,11 @@ class ConditionContext:
     __slots__ = "func", "annotations", "namelist", "depth"
 
     def __init__(self, condition: Union[_ContextLambda, bool], depth=2):
+        if (sys.version_info.major, sys.version_info.minor) >= (3, 14):
+            warnings.warn(
+                "Python3.14 breaks support for Contitional fields. Conditional "
+                "statements must be defined manually until a fix has been released."
+            )
         self.func = condition
         self.annotations = None
         self.namelist = None

--- a/src/caterpillar/exception.py
+++ b/src/caterpillar/exception.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/__init__.py
+++ b/src/caterpillar/fields/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/_base.py
+++ b/src/caterpillar/fields/_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/_mixin.py
+++ b/src/caterpillar/fields/_mixin.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/compression.py
+++ b/src/caterpillar/fields/compression.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/conditional.py
+++ b/src/caterpillar/fields/conditional.py
@@ -12,6 +12,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import sys
+import warnings
+
 from typing import Union, Any
 from typing import Optional
 from caterpillar.abc import _ContextLambda, _StructLike
@@ -38,6 +41,11 @@ class ConditionalChain:
     __slots__ = "chain", "conditions"
 
     def __init__(self, struct: _StructLike, condition: _ContextLambda) -> None:
+        if (sys.version_info.major, sys.version_info.minor) >= (3, 14):
+            warnings.warn(
+                "Python3.14 breaks support for Contitional fields. Conditional "
+                "statements must be defined manually until a fix has been released."
+            )
         self.chain = {}
         self.conditions = []
         self.add(struct, condition)

--- a/src/caterpillar/fields/conditional.py
+++ b/src/caterpillar/fields/conditional.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/conditional.py
+++ b/src/caterpillar/fields/conditional.py
@@ -96,6 +96,10 @@ class ConditionalChain:
 class If(ConditionContext):
     """If-statement implementation for class definitions.
 
+    .. versionchanged:: 2.4.5
+
+        Python 3.14 is **not** supported.
+
     .. code-block:: python
 
         @struct
@@ -121,6 +125,10 @@ class If(ConditionContext):
 
 class ElseIf(ConditionContext):
     """ElseIf-statement implementation for class definitions.
+
+    .. versionchanged:: 2.4.3
+
+        Python 3.14 is **not** supported.
 
     .. code-block:: python
 

--- a/src/caterpillar/fields/crypto.py
+++ b/src/caterpillar/fields/crypto.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/digest.py
+++ b/src/caterpillar/fields/digest.py
@@ -45,6 +45,8 @@ class _DigestValue:
 
 class Algorithm:
     """
+    .. versionadded:: 2.4.0
+
     A class representing a cryptographic or checksum algorithm.
 
     This class allows for the creation, updating, and finalization of values using a
@@ -163,9 +165,14 @@ class Algorithm:
 
 
 class Digest:
-    """
-    A class to handle the creation, updating, and verification of digests
+    """A class to handle the creation, updating, and verification of digests
     using a specified algorithm.
+
+    .. versionadded:: 2.4.0
+
+    .. versionchanged:: 2.4.3
+
+        Python 3.14 is **not** supported.
 
     The `Digest` class allows you to integrate hash or checksum algorithms
     into a struct by installing hooks that manage the digest state during

--- a/src/caterpillar/fields/digest.py
+++ b/src/caterpillar/fields/digest.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@ from typing import Any, Callable, Optional, Self, Type
 from caterpillar.abc import _ContextLike, _StructLike, _ContextLambda
 from caterpillar.context import CTX_OBJECT, CTX_STREAM
 from caterpillar.exception import StructException, ValidationError
-from caterpillar.shared import MODE_PACK, Action
+from caterpillar.shared import Action
 from caterpillar.fields.hook import (
     IOHook,
 )
@@ -290,9 +290,19 @@ class Digest:
             raise ValueError(
                 (
                     f"Digest with start action {self.name!r} already exists! "
-                    "Make sure that each checksum uses a unique name."
+                    "Make sure that each digest uses a unique name."
                 )
             )
+
+        if self.name in annotations:
+            raise ValueError(
+                (
+                    f"Digest with name {self.name!r} already exists "
+                    "before the start action. Make sure that each digest "
+                    "uses a unique name."
+                )
+            )
+
         annotations[start_action_name] = Action(self.begin, self.begin)
         return self
 

--- a/src/caterpillar/fields/hook.py
+++ b/src/caterpillar/fields/hook.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/net.py
+++ b/src/caterpillar/fields/net.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/pointer.py
+++ b/src/caterpillar/fields/pointer.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/fields/varint.py
+++ b/src/caterpillar/fields/varint.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/include/caterpillar/state.h
+++ b/src/caterpillar/include/caterpillar/state.h
@@ -53,7 +53,6 @@ struct _stateobj
   PyObject* m_offset_table;
 };
 
-
 /**
  * @brief Check whether the given object is a state
  *
@@ -74,7 +73,8 @@ struct _stateobj
 
 //-----------------------------------------------------------------------------
 // layer
-enum {
+enum
+{
   CpLayerClass_Default = 0,
   CpLayerClass_Sequence = 1,
   CpLayerClass_Object = 2,
@@ -88,8 +88,8 @@ struct _layerobj
 {
   PyObject_HEAD
 
-  /// The parent layer
-  struct _layerobj* m_parent;
+    /// The parent layer
+    struct _layerobj* m_parent;
 
   /// the global parsing state
   CpStateObject* m_state;
@@ -117,8 +117,10 @@ struct _layerobj
 
   // /// When packing or unpacking objects, the current object attributes are
   // /// stored within an object context. This is a special context that allows
-  // /// access to previously parsed fields or attributes of the input object. To
-  // /// minimize the number of calls using this attribute, a shortcut named `this`
+  // /// access to previously parsed fields or attributes of the input object.
+  // To
+  // /// minimize the number of calls using this attribute, a shortcut named
+  // `this`
   // /// was defined, which automatically inserts a path to the object context.
   // PyObject* m_obj;
 
@@ -133,7 +135,8 @@ struct _layerobj
   // Py_ssize_t m_length;
 
   // /// When packing or unpacking collections of elements, the current working
-  // /// index is given under this layer variable. It is set only in this specific
+  // /// index is given under this layer variable. It is set only in this
+  // specific
   // /// situation.
   // Py_ssize_t m_index;
 
@@ -165,10 +168,11 @@ struct _layerobj
   Py_XSETREF(                                                                  \
     (layer)->m_path,                                                           \
     PyUnicode_FromFormat("%s.%s",                                              \
-                         _PyUnicode_AsString((layer)->m_parent                 \
-                                               ? (layer)->m_parent->m_path     \
-                                               : (layer)->m_path),             \
-                         _PyUnicode_AsString((newpath))));
+                         PyUnicode_AsUTF8AndSize((layer)->m_parent             \
+                                                   ? (layer)->m_parent->m_path \
+                                                   : (layer)->m_path,          \
+                                                 NULL),                        \
+                         PyUnicode_AsUTF8AndSize((newpath), NULL)));
 
 //-----------------------------------------------------------------------------
 // seq layer
@@ -177,8 +181,8 @@ struct _seqlayerobj
 {
   CpLayer_HEAD
 
-  /// Same as `m_obj` but for the sequential elements.
-  PyObject* m_sequence;
+    /// Same as `m_obj` but for the sequential elements.
+    PyObject* m_sequence;
 
   /// The length of the current collection.
   Py_ssize_t m_length;
@@ -201,12 +205,13 @@ struct _objlayerobj
 {
   CpLayer_HEAD
 
-  /// When packing or unpacking objects, the current object attributes are
-  /// stored within an object context. This is a special context that allows
-  /// access to previously parsed fields or attributes of the input object. To
-  /// minimize the number of calls using this attribute, a shortcut named `this`
-  /// was defined, which automatically inserts a path to the object context.
-  PyObject* m_obj;
+    /// When packing or unpacking objects, the current object attributes are
+    /// stored within an object context. This is a special context that allows
+    /// access to previously parsed fields or attributes of the input object. To
+    /// minimize the number of calls using this attribute, a shortcut named
+    /// `this` was defined, which automatically inserts a path to the object
+    /// context.
+      PyObject* m_obj;
 };
 
 #define CpObjLayer_CheckExact(v) Py_IS_TYPE((v), &CpObjLayer_Type)

--- a/src/caterpillar/model/__init__.py
+++ b/src/caterpillar/model/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/model/_base.py
+++ b/src/caterpillar/model/_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/model/_bitfield.py
+++ b/src/caterpillar/model/_bitfield.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/model/_struct.py
+++ b/src/caterpillar/model/_struct.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/model/_template.py
+++ b/src/caterpillar/model/_template.py
@@ -1,5 +1,5 @@
 # pylint: disable=protected-access
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/options.py
+++ b/src/caterpillar/options.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/registry.py
+++ b/src/caterpillar/registry.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/shared.py
+++ b/src/caterpillar/shared.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,8 +16,9 @@ from typing import Any, Callable
 from caterpillar.abc import _ContextLike
 
 # --- Shared Concepts ---
-# TODO: This section need some docs
+# TODO: This section needs some docs
 
+# additional modifies set in the root context of each operation
 MODE_PACK = 0
 MODE_UNPACK = 1
 
@@ -85,10 +86,10 @@ class Action:
     The action itself is not stored as part of the struct's model; it merely runs
     during struct processing.
 
-    :param run_pack: The callable that will be executed before packing the struct (optional).
-    :type run_pack: Callable[[_ContextLike], None] | None
-    :param run_unpack: The callable that will be executed before unpacking the struct (optional).
-    :type run_unpack: Callable[[_ContextLike], None] | None
+    :param pack: The callable that will be executed before packing the struct (optional).
+    :type pack: Callable[[_ContextLike], None] | None
+    :param unpack: The callable that will be executed before unpacking the struct (optional).
+    :type unpack: Callable[[_ContextLike], None] | None
     """
 
     __slots__ = (ATTR_ACTION_PACK, ATTR_ACTION_UNPACK)

--- a/src/caterpillar/shortcuts.py
+++ b/src/caterpillar/shortcuts.py
@@ -1,4 +1,4 @@
-# Copyright (C) MatrixEditor 2023-2024
+# Copyright (C) MatrixEditor 2023-2025
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/ccaterpillar/atomimpl/builtins/repeated.c
+++ b/src/ccaterpillar/atomimpl/builtins/repeated.c
@@ -205,7 +205,7 @@ CpRepeatedAtom_Pack(CpRepeatedAtomObject* self,
       goto failure;
     }
     seq_layer->ob_base.m_path = PyUnicode_FromFormat(
-      "%s.%d", _PyUnicode_AsString(layer->m_path), seq_layer->m_index);
+      "%s.%d", PyUnicode_AsUTF8AndSize(layer->m_path, NULL), seq_layer->m_index);
     if (!seq_layer->ob_base.m_path) {
       Py_XDECREF(obj);
       goto failure;
@@ -283,7 +283,7 @@ CpRepeatedAtom_Unpack(CpRepeatedAtomObject* self, CpLayerObject* layer)
     seq_layer, seq, lengthinfo->m_length, lengthinfo->m_greedy);
   while (seq_layer->s_greedy || (seq_layer->m_index < seq_layer->m_length)) {
     seq_layer->ob_base.m_path = PyUnicode_FromFormat(
-      "%s.%d", _PyUnicode_AsString(layer->m_path), seq_layer->m_index);
+      "%s.%d", PyUnicode_AsUTF8AndSize(layer->m_path, NULL), seq_layer->m_index);
     if (!seq_layer->ob_base.m_path) {
       goto fail;
     }

--- a/src/ccaterpillar/default.c
+++ b/src/ccaterpillar/default.c
@@ -2,6 +2,10 @@
 
 #include "caterpillar/caterpillar.h"
 
+#if PY_3_13_PLUS
+#define _Py_IMMORTAL_REFCNT _Py_IMMORTAL_INITIAL_REFCNT
+#endif
+
 static PyObject*
 cp_invaliddefault_new(PyTypeObject* type, PyObject* args, PyObject* kw)
 {

--- a/src/ccaterpillar/pyproject.toml
+++ b/src/ccaterpillar/pyproject.toml
@@ -18,7 +18,7 @@ CP_ENABLE_NATIVE = "1"
 
 [project]
 name = "caterpillar"
-version = "2.4.2"
+version = "2.4.3"
 
 description="Library to pack and unpack structurized binary data."
 authors = [

--- a/src/ccaterpillar/struct.c
+++ b/src/ccaterpillar/struct.c
@@ -1003,7 +1003,12 @@ cp_struct_add_slots(CpStructObject* self)
     }
   }
 
-  // Get rid of the __dict__ attribute
+// Get rid of the __dict__ attribute
+#if PY_3_13_PLUS
+  PyDict_Pop(dict, state->str___dict__, NULL);
+  PyDict_Pop(dict, state->str___weakref__, NULL);
+
+#else
   PyObject* tmp = _PyDict_Pop(dict, state->str___dict__, NULL);
   Py_XDECREF(tmp);
 
@@ -1011,6 +1016,7 @@ cp_struct_add_slots(CpStructObject* self)
   // because it belongs to the previous type.
   tmp = _PyDict_Pop(dict, state->str___weakref__, NULL);
   Py_XDECREF(tmp);
+#endif
 
   PyObject* tuple = PyList_AsTuple(slots);
   if (!tuple) {

--- a/test/_Py/fields/test_py_digest.py
+++ b/test/_Py/fields/test_py_digest.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 from caterpillar.exception import ValidationError
 from caterpillar.py import Bytes, unpack, pack, struct
@@ -6,36 +7,37 @@ from caterpillar.fields.digest import Md5, Sha2_256, _DigestValue
 from caterpillar.shared import ATTR_ACTION_PACK
 
 
-@struct
-class FormatMd5:
-    with Md5("hash", verify=False):
-        user_data: Bytes(10)
-
-
-def test_digest_init():
-    # must be an action
-    # actions are stored in tuples
-    assert hasattr(FormatMd5.__struct__.fields[0][0], ATTR_ACTION_PACK)
-
-    obj = FormatMd5(user_data=b"1234567890")
-    assert obj.hash.__class__ is _DigestValue
-
-
-def test_digest_md5():
-    obj = FormatMd5(user_data=b"1234567890")
-    valid = b"1234567890\xe8\x07\xf1\xfc\xf8-\x13/\x9b\xb0\x18\xcag8\xa1\x9f"
-
-    assert pack(obj) == valid
-    # as verify is set to false, we can parse arbitrary hashes
-    assert unpack(FormatMd5, valid[:-1] + b"0")
-
-
-def test_digest_verify():
+if (sys.version_info.major, sys.version_info.minor) < (3, 14):
     @struct
-    class FormatSha2_256:
-        with Sha2_256("hash", verify=True):
+    class FormatMd5:
+        with Md5("hash", verify=False):
             user_data: Bytes(10)
 
-    invalid = b"1234567890" + b"\x00" * 32
-    with pytest.raises(ValidationError):
-        unpack(FormatSha2_256, invalid)
+
+    def test_digest_init():
+        # must be an action
+        # actions are stored in tuples
+        assert hasattr(FormatMd5.__struct__.fields[0][0], ATTR_ACTION_PACK)
+
+        obj = FormatMd5(user_data=b"1234567890")
+        assert obj.hash.__class__ is _DigestValue
+
+
+    def test_digest_md5():
+        obj = FormatMd5(user_data=b"1234567890")
+        valid = b"1234567890\xe8\x07\xf1\xfc\xf8-\x13/\x9b\xb0\x18\xcag8\xa1\x9f"
+
+        assert pack(obj) == valid
+        # as verify is set to false, we can parse arbitrary hashes
+        assert unpack(FormatMd5, valid[:-1] + b"0")
+
+
+    def test_digest_verify():
+        @struct
+        class FormatSha2_256:
+            with Sha2_256("hash", verify=True):
+                user_data: Bytes(10)
+
+        invalid = b"1234567890" + b"\x00" * 32
+        with pytest.raises(ValidationError):
+            unpack(FormatSha2_256, invalid)


### PR DESCRIPTION
[Python 3.14 annotations](https://docs.python.org/3.14/howto/annotations.html) are handled and placed differently compared to previous versions. Until a fix is available for `Digest` and `ConditionalContext`, `with` statements are **not** supported in class definitions.