### PR TITLE
[HOTFIX] Bitfield packing and unpacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.5.1] - Hot-Fix Release
+
+### Fixed
+
+- **caterpillar.model**
+   - An issue when packing or unpacking a bitfield with unnamed fields AND `S_DISCARD_UNNAMED` enabled
+
+
 ## [2.5.0] - Minor Release
 
 ### Added

--- a/docs/sphinx/source/development/changelog.rst
+++ b/docs/sphinx/source/development/changelog.rst
@@ -6,6 +6,20 @@ Changelog
 
 *More entries will be added in the future.*
 
+.. _changelog_2.5.1:
+
+[2.5.1] - Hot-Fix Release
+=========================
+
+Fixed
+-----
+
+*caterpillar.model*
+^^^^^^^^^^^^^^^^^^^
+
+- An issue when packing or unpacking a bitfield with unnamed fields AND :attr:`S_DISCARD_UNNAMED` enabled
+
+
 .. _changelog_2.5.0:
 
 [2.5.0] - Minor Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ cmake.source-dir = "."
 
 [project]
 name = "caterpillar"
-version = "2.5.0"
+version = "2.5.1"
 
 description="Library to pack and unpack structurized binary data."
 authors = [{ name = "MatrixEditor" }]

--- a/src/caterpillar/__init__.py
+++ b/src/caterpillar/__init__.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import warnings
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 __release__ = None
 __author__ = "MatrixEditor"
 

--- a/src/caterpillar/model/_bitfield.py
+++ b/src/caterpillar/model/_bitfield.py
@@ -930,6 +930,9 @@ class Bitfield(Struct):
                             func(context)
                             continue
 
+                    if entry.name not in self._member_map_:
+                        continue
+
                     value = (raw_value >> entry.shift(group.bit_count)) & entry.low_mask
                     if entry.factory:
                         value = entry.factory.from_int(value)
@@ -961,6 +964,9 @@ class Bitfield(Struct):
                         func = getattr(entry.action, ATTR_ACTION_PACK, None)
                         if func:
                             func(context)
+                        continue
+
+                    if entry.name not in self._member_map_:
                         continue
 
                     entry_value = self.get_value(obj, entry.name, None)

--- a/src/ccaterpillar/pyproject.toml
+++ b/src/ccaterpillar/pyproject.toml
@@ -18,7 +18,7 @@ CP_ENABLE_NATIVE = "1"
 
 [project]
 name = "caterpillar"
-version = "2.5.0"
+version = "2.5.1"
 
 description = "Library to pack and unpack structurized binary data."
 readme = "../../README.md"


### PR DESCRIPTION
## Fixed

- Fix an issue with packing and unpacking bitfields storing unnamed fields and `S_DISCARD_UNNAMED` enabled
- Bump version to 2.5.1