### PR TITLE
[DEV] (2.6.0-rc) CAPI Atom and LengthInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ venv-matrix/
 *.so
 include/caterpillar/caterpillar.h
 src/ccaterpillar/caterpillarapi.c
+src/ccaterpillar/module.c
+src/ccaterpillar/private.h
 
 # Distribution / packaging
 .Python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ python_add_library(
   src/ccaterpillar/option.c
   src/ccaterpillar/module.c
   src/ccaterpillar/context.c
+  src/ccaterpillar/atom.c
+  src/ccaterpillar/lengthinfo.c
 
   WITH_SOABI
 )
@@ -32,15 +34,20 @@ message(STATUS "Python ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
 set (CP_GENAPI_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/src/code_gen/genapi.py)
 set (CP_CAPI_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/src/caterpillar/include/caterpillar/caterpillarapi.h.in)
 set (CP_CAPI_CSRC ${CMAKE_CURRENT_SOURCE_DIR}/src/ccaterpillar/caterpillarapi.c.in)
+set (CP_CAPI_MOD_CSRC ${CMAKE_CURRENT_SOURCE_DIR}/src/ccaterpillar/module.c.in)
+set (CP_CAPI_PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/ccaterpillar/private.h.in)
+
 set (CP_CAPI_HEADER_OUT ${CMAKE_CURRENT_SOURCE_DIR}/src/caterpillar/include/caterpillar/caterpillarapi.h)
 set (CP_CAPI_CSRC_OUT ${CMAKE_CURRENT_SOURCE_DIR}/src/ccaterpillar/caterpillarapi.c)
+set (CP_CAPI_MOD_CSRC_OUT ${CMAKE_CURRENT_SOURCE_DIR}/src/ccaterpillar/module.c)
+set (CP_CAPI_PRIVATE_OUT ${CMAKE_CURRENT_SOURCE_DIR}/src/ccaterpillar/private.h)
 
 add_custom_target(
  genapi ALL
  # execute python ./src/code_gen/genapi.py ./src/caterpillar/include/caterpillar/caterpillarapi.h.in ./src/ccaterpillar/caterpillarapi.c.in
  # in the root directory
- COMMAND ${PYTHON_EXECUTABLE} ${CP_GENAPI_SCRIPT} ${CP_CAPI_HEADER} ${CP_CAPI_CSRC}
- BYPRODUCTS ${CP_CAPI_HEADER_OUT} ${CP_CAPI_CSRC_OUT}
+ COMMAND ${PYTHON_EXECUTABLE} ${CP_GENAPI_SCRIPT} ${CP_CAPI_HEADER} ${CP_CAPI_CSRC} ${CP_CAPI_MOD_CSRC} ${CP_CAPI_PRIVATE}
+ BYPRODUCTS ${CP_CAPI_HEADER_OUT} ${CP_CAPI_CSRC_OUT} ${CP_CAPI_MOD_CSRC_OUT} ${CP_CAPI_PRIVATE_OUT}
  COMMENT "Generating Public Caterpillar API"
 )
 

--- a/src/capi.dat
+++ b/src/capi.dat
@@ -19,12 +19,15 @@
 #       Defines a C API function. The function must be present within the
 #       source set of this file.
 #
-#   src:FILE
+#   src:FILE:IGNORE
 #       Defines the source file (relative to this file) that contains the
-#       function definitions.
+#       function definitions. IGNORE indicates this file won't be used to
+#       generate the module file.
 
 src:ccaterpillar/arch.c
 src:ccaterpillar/context.c
+src:ccaterpillar/atom.c
+src:ccaterpillar/option.c
 
 # First index is reserved for the global module reference
 obj:0:CpModule:PyModuleDef
@@ -59,3 +62,6 @@ func:-:CpContext_New:PyObject*:+1
 func:-:CpContext_GetDict:PyObject*:+1
 func:9:CpContext_GenericSetAttr:int:null
 func:10:CpContext_GenericSetAttrString:int:null
+
+# CpAtom API
+type:11:_atomobj:CpAtomObject:Atom

--- a/src/capi.dat
+++ b/src/capi.dat
@@ -28,6 +28,7 @@ src:ccaterpillar/arch.c
 src:ccaterpillar/context.c
 src:ccaterpillar/atom.c
 src:ccaterpillar/option.c
+src:ccaterpillar/lengthinfo.c
 
 # First index is reserved for the global module reference
 obj:0:CpModule:PyModuleDef
@@ -65,3 +66,13 @@ func:10:CpContext_GenericSetAttrString:int:null
 
 # CpAtom API
 type:11:_atomobj:CpAtomObject:Atom
+
+# Length info
+type:20:_lengthinfoobj:CpLengthInfoObject:LengthInfo
+func:-:CpLengthInfo_New:PyObject*:+1
+func:-:CpLengthInfo_Length:int:null
+func:-:CpLengthInfo_IsGreedy:int:null
+func:-:CpLengthInfo_LengthAsLong:PyObject*:+1
+func:-:CpLengthInfo_SetLengthFromLong:int:null
+func:-:CpLengthInfo_SetLength:int:null
+func:-:CpLengthInfo_SetGreedy:void:null

--- a/src/caterpillar/_C.pyi
+++ b/src/caterpillar/_C.pyi
@@ -1,6 +1,8 @@
-from typing import Any
+from collections.abc import Iterable
+from typing import Any, Generic
 from caterpillar.abc import (
     _OT,
+    _IT,
     _ArchLike,
     _EndianLike,
     _SupportsSetEndian,
@@ -48,12 +50,38 @@ class c_Option:
 class c_Context(dict, _ContextLike):
     def __init__(self, **kwargs) -> None: ...
 
+class LengthInfo:
+    length: int
+    greedy: bool
+    def __init__(self, length: int = ..., greedy: bool = ...) -> None: ...
+
+class Atom(Generic[_IT, _OT]):
+    def __pack__(self, obj: _IT, context: _ContextLike) -> None: ...
+    def __pack_many__(
+        self,
+        obj: Iterable[_IT],
+        context: _ContextLike,
+        lengthinfo: LengthInfo,
+    ) -> None: ...
+    def __unpack__(self, context: _ContextLike) -> _OT: ...
+    def __unpack_many__(
+        self,
+        context: _ContextLike,
+        lengthinfo: LengthInfo,
+    ) -> Iterable[_OT]: ...
+    def __type__(self) -> type | str | None: ...
+    def __size__(self, context: _ContextLike) -> int: ...
+    def __bits__(self) -> int: ...
+
 __all__ = [
     "c_Arch",
     "c_Endian",
     "c_Option",
+    "c_Context",
     "BIG_ENDIAN",
     "HOST_ARCH",
     "LITTLE_ENDIAN",
     "NATIVE_ENDIAN",
+    "Atom",
+    "LengthInfo",
 ]

--- a/src/caterpillar/abc.py
+++ b/src/caterpillar/abc.py
@@ -154,3 +154,20 @@ class _SupportsBits(Protocol):
 @runtime_checkable
 class _ContainsBits(Protocol):
     __bits__: int
+
+
+__all__ = [
+    "_ContextLike",
+    "_ContextLambda",
+    "_SupportsActionUnpack",
+    "_SupportsActionPack",
+    "_SupportsPack",
+    "_SupportsUnpack",
+    "_SupportsSize",
+    "_StructLike",
+    "_SupportsType",
+    "_ContainsStruct",
+    "_SwitchLike",
+    "_SupportsBits",
+    "_ContainsBits",
+]

--- a/src/caterpillar/abc.pyi
+++ b/src/caterpillar/abc.pyi
@@ -14,7 +14,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from io import IOBase
 from types import EllipsisType
-from typing import Any, Callable, Optional, Protocol, TypeVar, Union, runtime_checkable
+from typing import (
+    Any,
+    Callable,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+    runtime_checkable,
+    type_check_only,
+)
 
 _IT = TypeVar("_IT")
 _IT_co = TypeVar("_IT_co", covariant=True)
@@ -82,6 +91,10 @@ class _SupportsSize(Protocol):
     def __size__(self, context: _ContextLike) -> int: ...
 
 @runtime_checkable
+class _SupportsType(Protocol):
+    def __type__(self) -> type | str | None: ...
+
+@runtime_checkable
 class _SupportsUnpack(Protocol[_OT_co]):
     def __unpack__(self, context: _ContextLike) -> _OT_co: ...
 
@@ -99,25 +112,41 @@ class _SupportsBits(Protocol):
 class _ContainsBits(Protocol):
     __bits__: int
 
-@runtime_checkable
+@type_check_only
 class _ArchLike(Protocol):
     name: str
     ptr_size: int
 
     def __init__(self, name: str, ptr_size: int) -> None: ...
 
-@runtime_checkable
+@type_check_only
 class _SupportsSetEndian(Protocol[_OT_co]):
     def __set_byteorder__(self, order: _EndianLike) -> _OT_co: ...
 
-@runtime_checkable
+@type_check_only
 class _EndianLike(Protocol):
     name: str
     ch: str
 
     def __add__(self, other: _SupportsSetEndian[_OT]) -> _OT: ...
 
-@runtime_checkable
+@type_check_only
 class _OptionLike(Protocol):
     name: str
     value: Any
+
+__all__ = [
+    "_ContextLike",
+    "_ContextLambda",
+    "_SupportsActionUnpack",
+    "_SupportsActionPack",
+    "_SupportsPack",
+    "_SupportsUnpack",
+    "_SupportsSize",
+    "_StructLike",
+    "_SupportsType",
+    "_ContainsStruct",
+    "_SwitchLike",
+    "_SupportsBits",
+    "_ContainsBits",
+]

--- a/src/caterpillar/context.pyi
+++ b/src/caterpillar/context.pyi
@@ -24,7 +24,7 @@ from typing import (
     Type,
     Union,
     dataclass_transform,
-    TYPE_CHECKING,
+    type_check_only,
 )
 from caterpillar.abc import _ContextLike, _ContextLambda
 from caterpillar.options import Flag
@@ -42,9 +42,9 @@ CTX_SEQ: str = ...
 CTX_ARCH: str = ...
 CTX_ROOT: str = ...
 
-if TYPE_CHECKING:
-    class ContextFactory(Protocol):
-        def __call__(self, **kwds) -> _ContextLike: ...
+@type_check_only
+class ContextFactory(Protocol):
+    def __call__(self, **kwds) -> _ContextLike: ...
 
 O_CONTEXT_FACTORY: Flag[Type[_ContextLike] | ContextFactory]
 

--- a/src/caterpillar/include/caterpillar/arch.h
+++ b/src/caterpillar/include/caterpillar/arch.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) MatrixEditor 2024
+ * Copyright (C) MatrixEditor 2025
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/include/caterpillar/atom.h
+++ b/src/caterpillar/include/caterpillar/atom.h
@@ -1,0 +1,213 @@
+/**
+ * Copyright (C) MatrixEditor 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef ATOMOBJ_H
+#define ATOMOBJ_H
+
+#include "caterpillarapi.h"
+
+// ---------------------------------------------------------------------------
+// CAtom
+
+/**
+ * @brief Size-Protocol
+ *
+ * Each atom object may implement the `__size__` method, which is used
+ * to determine the size of the object. Its C function pointer must conform
+ * to this type definition.
+ *
+ * The signature of this function is as follows:
+ * @code {.cpp}
+ * PyObject* sizefunc(PyObject* self, PyObject* ctx);
+ * @endcode
+ *
+ * @param atom the atom object (self)
+ * @param ctx the context object
+ * @return the size of the object
+ */
+typedef PyObject* (*sizefunc)(PyObject*, PyObject*);
+
+/**
+ * @brief Type-Protocol
+ *
+ * In order to replace types accordingly, each atom object may implement
+ * the `__type__` method. It must return a new type object, or
+ * `NotImplemented` for any type.
+ *
+ * The signature of this function is as follows:
+ * @code {.cpp}
+ * PyObject* typefunc(PyObject* self, PyObject* ctx);
+ * @endcode
+ *
+ * @param atom the atom object (self)
+ * @param ctx the context object
+ * @return the type of the object
+ */
+typedef PyObject* (*typefunc)(PyObject*);
+
+/**
+ * @brief Pack-Protocol
+ *
+ * Each atom object may implement the `__pack__` method, which is used
+ * to pack an object to the underlying stream. Note that the context
+ * parameter is set to a `PyObject` instead of a specialized `CpContext`
+ * or `CpLayer`. The provided context object must implement the context
+ * protocol, therefore this function is context type independent.
+ *
+ * The signature of this function is as follows:
+ * @code {.cpp}
+ * int packfunc(PyObject* self, PyObject* op, PyObject* ctx);
+ * @endcode
+ *
+ * @param self the atom object (self)
+ * @param op the object to pack
+ * @param ctx the context object
+ * @return the result of the `__pack__` method
+ */
+typedef int (*packfunc)(PyObject*, PyObject*, PyObject*);
+
+/**
+ * @brief Pack-Protocol (many)
+ *
+ * This is another specialized version of the `packfunc` function, which
+ * is used to pack multiple objects to the underlying stream. See `packfunc`
+ * for more information.
+ *
+ * The signature of this function is as follows:
+ * @code {.cpp}
+ * int packmanyfunc(PyObject* self, PyObject* op, PyObject* ctx,
+ *                  CpLengthInfo* info);
+ * @endcode
+ *
+ * @param self the atom object (self)
+ * @param op the object to pack
+ * @param ctx the context object
+ * @param info the length information
+ * @return the result of the `__pack_many__` method
+ */
+typedef int (*packmanyfunc)(PyObject*, PyObject*, PyObject*, PyObject*);
+
+/**
+ * @brief Unpack-Protocol
+ *
+ * Each atom object may implement the `__unpack__` method, which is used
+ * to unpack an object from the underlying stream. The same notes from
+ * the `packfunc` apply here.
+ *
+ * @param self the atom object (self)
+ * @param ctx the context object
+ * @return the result of the `__unpack__` method, or `NULL` on error
+ */
+typedef PyObject* (*unpackfunc)(PyObject*, PyObject*);
+
+/**
+ * @brief Unpack-Protocol (many)
+ *
+ * This is another specialized version of the `unpackfunc` function, which
+ * is used to unpack multiple objects from the underlying stream. See
+ * `unpackfunc` for more information.
+ *
+ * The signature of this function is as follows:
+ * @code {.cpp}
+ * PyObject* unpackmanyfunc(PyObject* self, PyObject* ctx,
+ *                          CpLengthInfo* info);
+ * @endcode
+ *
+ * @param self the atom object (self)
+ * @param ctx the context object
+ * @param info the length information
+ * @return the result of the `__unpack_many__` method
+ */
+typedef PyObject* (*unpackmanyfunc)(PyObject*, PyObject*, PyObject*);
+
+/// Experimental API
+/**
+ * @brief Bits-Protocol
+ *
+ * Each atom object may implement the `__bits__` method, which is only used
+ * by the `Bitfield` class. It must return the amount of bits the object
+ * occupies.
+ *
+ * The signature of this function is as follows:
+ * @code {.cpp}
+ * PyObject* bitsfunc(PyObject* self);
+ * @endcode
+ *
+ * @param atom the atom object (self)
+ * @param ctx the context object
+ * @return the result of the `__bits__` method
+ */
+typedef PyObject* (*bitsfunc)(PyObject*);
+
+/**
+ * @brief Defines the base type for atom objects to be a CAtom
+ */
+#define CpAtom_HEAD CpAtomObject ob_base;
+
+/**
+ * @brief Atom object for C types
+ */
+struct _atomobj
+{
+  PyObject_HEAD;
+
+  // C functions to implement
+  sizefunc ob_size;
+  typefunc ob_type;
+  packfunc ob_pack;
+  packmanyfunc ob_pack_many;
+  unpackfunc ob_unpack;
+  unpackmanyfunc ob_unpack_many;
+  bitsfunc ob_bits;
+};
+
+#define CpAtom_CheckExact(op) Py_IS_TYPE((op), &CpAtom_Type)
+#define CpAtom_Check(op) PyObject_TypeCheck((op), &CpAtom_Type)
+
+#define CpAtom_Pack_STR "__pack__"
+#define CpAtom_Unpack_STR "__unpack__"
+#define CpAtom_PackMany_STR "__pack_many__"
+#define CpAtom_UnpackMany_STR "__unpack_many__"
+#define CpAtom_Size_STR "__size__"
+#define CpAtom_Type_STR "__type__"
+#define CpAtom_Bits_STR "__bits__"
+
+// default utility macros
+
+/**
+ * @brief Checks if the given object has an attribute
+ */
+#define CpAtom_HasAttr(op, name) PyObject_HasAttr((op), (name))
+
+#define CpAtom_HasPack(op) PyObject_HasAttrString((op), CpAtom_Pack_STR)
+#define CpAtom_HasUnpack(op) PyObject_HasAttrString((op), CpAtom_Unpack_STR)
+#define CpAtom_HasPackMany(op) PyObject_HasAttrString((op), CpAtom_PackMany_STR)
+#define CpAtom_HasUnpackMany(op)                                               \
+  PyObject_HasAttrString((op), CpAtom_UnpackMany_STR)
+#define CpAtom_HasSize(op) PyObject_HasAttrString((op), CpAtom_Size_STR)
+#define CpAtom_HasType(op) PyObject_HasAttrString((op), CpAtom_Type_STR)
+#define CpAtom_HasBits(op) PyObject_HasAttrString((op), CpAtom_Bits_STR)
+
+#define Cp_ATOM(op) (op)->ob_base
+
+static inline PyObject*
+CpAtom_New(void)
+{
+  return CpObject_CreateNoArgs(&CpAtom_Type);
+}
+
+
+#endif // ATOMOBJ_H

--- a/src/caterpillar/include/caterpillar/caterpillar.h
+++ b/src/caterpillar/include/caterpillar/caterpillar.h
@@ -4,9 +4,11 @@
 // API includes
 #include "caterpillar/caterpillarapi.h"
 
-#include "caterpillar/module.h"
 #include "caterpillar/arch.h"
-#include "caterpillar/option.h"
+#include "caterpillar/atom.h"
 #include "caterpillar/context.h"
+#include "caterpillar/module.h"
+#include "caterpillar/option.h"
+#include "caterpillar/lengthinfo.h"
 
 #endif

--- a/src/caterpillar/include/caterpillar/context.h
+++ b/src/caterpillar/include/caterpillar/context.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) MatrixEditor 2024
+ * Copyright (C) MatrixEditor 2025
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/include/caterpillar/lengthinfo.h
+++ b/src/caterpillar/include/caterpillar/lengthinfo.h
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) MatrixEditor 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef LENGTHINFO_H
+#define LENGTHINFO_H
+
+#include "caterpillarapi.h"
+
+// ---------------------------------------------------------------------------
+// Length Hint
+
+struct _lengthinfoobj
+{
+  PyObject_HEAD;
+
+  Py_ssize_t m_length;
+  int m_greedy;
+};
+
+static inline PyObject*
+CpLengthInfo_New(Py_ssize_t pLength, int pGreedy)
+{
+  return CpObject_Create(&CpLengthInfo_Type, "np", pLength, pGreedy);
+}
+
+static inline Py_ssize_t
+CpLengthInfo_Length(PyObject* pObj)
+{
+  return _Cp_CAST(CpLengthInfoObject*, pObj)->m_length;
+}
+
+static inline int
+CpLengthInfo_IsGreedy(PyObject* pObj)
+{
+  return _Cp_CAST(CpLengthInfoObject*, pObj)->m_greedy;
+}
+
+static inline void
+CpLengthInfo_SetGreedy(PyObject* pObj, int pGreedy)
+{
+  _Cp_CAST(CpLengthInfoObject*, pObj)->m_greedy = pGreedy;
+}
+
+static inline PyObject*
+CpLengthInfo_LengthAsLong(PyObject* pObj)
+{
+  return PyLong_FromSsize_t(_Cp_CAST(CpLengthInfoObject*, pObj)->m_length);
+}
+
+static inline int
+CpLengthInfo_SetLength(PyObject* pObj, Py_ssize_t pLength)
+{
+  if (pLength < 0) {
+    PyErr_SetString(PyExc_ValueError, "New length must not be negative!");
+    return -1;
+  }
+  _Cp_CAST(CpLengthInfoObject*, pObj)->m_length = pLength;
+  return 0;
+}
+
+static inline int
+CpLengthInfo_SetLengthFromLong(PyObject* pObj, PyObject* pLengthObj)
+{
+  Py_ssize_t vLength = 0;
+  if (!pLengthObj) {
+    PyErr_SetString(PyExc_ValueError, "New length must not be NULL!");
+    return -1;
+  }
+
+  vLength = PyLong_AsSsize_t(pLengthObj);
+  PyErr_Clear();
+  return CpLengthInfo_SetLength(pObj, vLength);
+}
+
+#endif // LENGTHINFO_H

--- a/src/caterpillar/include/caterpillar/macros.h
+++ b/src/caterpillar/include/caterpillar/macros.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) MatrixEditor 2024
+ * Copyright (C) MatrixEditor 2025
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/include/caterpillar/module.h
+++ b/src/caterpillar/include/caterpillar/module.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) MatrixEditor 2024
+ * Copyright (C) MatrixEditor 2025
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/caterpillar/include/caterpillar/option.h
+++ b/src/caterpillar/include/caterpillar/option.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) MatrixEditor 2024
+ * Copyright (C) MatrixEditor 2025
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/ccaterpillar/atom.c
+++ b/src/ccaterpillar/atom.c
@@ -1,0 +1,223 @@
+#include "caterpillar/caterpillar.h"
+#include "private.h"
+
+#include <stddef.h>
+#include <structmember.h>
+
+static PyObject*
+cp_atom_new(PyTypeObject* type, PyObject* args, PyObject* kw)
+{
+  CpAtomObject* self = NULL;
+  if ((self = (CpAtomObject*)type->tp_alloc(type, 0), !self)) {
+    return NULL;
+  }
+
+  self->ob_bits = NULL;
+  self->ob_pack = NULL;
+  self->ob_pack_many = NULL;
+  self->ob_unpack = NULL;
+  self->ob_unpack_many = NULL;
+  self->ob_size = NULL;
+  self->ob_type = NULL;
+  return _Cp_CAST(PyObject*, self);
+}
+
+static void
+cp_atom_dealloc(CpAtomObject* self)
+{
+  self->ob_bits = NULL;
+  self->ob_pack = NULL;
+  self->ob_pack_many = NULL;
+  self->ob_unpack = NULL;
+  self->ob_unpack_many = NULL;
+  self->ob_size = NULL;
+  self->ob_type = NULL;
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static int
+cp_atom_init(CpAtomObject* self, PyObject* args, PyObject* kw)
+{
+  // We don't have to initialize anything here, because subclasses
+  // will overload the `__init__` method and place their method
+  // implementations.
+  _Cp_InitNoArgs(CAtoms, args, kw);
+}
+
+static PyObject*
+cp_atom_pack(CpAtomObject* self, PyObject* args, PyObject* kw)
+{
+  static char* kwlist[] = { "obj", "context", NULL };
+  PyObject *op = NULL, *context = NULL;
+  if (!self->ob_pack) {
+    PyErr_Format(PyExc_NotImplementedError,
+                 "The atom of type '%s' cannot be packed (missing __pack__)",
+                 Py_TYPE(self)->tp_name);
+    return NULL;
+  }
+
+  if (PyArg_ParseTupleAndKeywords(args, kw, "OO", kwlist, &op, &context) < 0) {
+    return NULL;
+  }
+
+  return self->ob_pack((PyObject*)self, op, context) ? NULL
+                                                     : Py_NewRef(Py_None);
+}
+
+static PyObject*
+cp_atom_pack_many(CpAtomObject* self, PyObject* args, PyObject* kw)
+{
+  static char* kwlist[] = { "obj", "context", "lengthinfo", NULL };
+  PyObject *ops = NULL, *context = NULL, *lengthinfo = NULL;
+  if (!self->ob_pack_many) {
+    PyErr_Format(
+      PyExc_NotImplementedError,
+      "The atom of type '%s' cannot be packed (missing __pack_many__)",
+      Py_TYPE(self)->tp_name);
+    return NULL;
+  }
+
+  if (PyArg_ParseTupleAndKeywords(
+        args, kw, "OOO", kwlist, &ops, &context, &lengthinfo) < 0) {
+    return NULL;
+  }
+
+  return self->ob_pack_many((PyObject*)self, ops, context, lengthinfo)
+           ? NULL
+           : Py_NewRef(Py_None);
+}
+
+static PyObject*
+cp_atom_unpack(CpAtomObject* self, PyObject* args, PyObject* kw)
+{
+  static char* kwlist[] = { "context", NULL };
+  PyObject* context = NULL;
+
+  if (!self->ob_unpack) {
+    PyErr_Format(
+      PyExc_NotImplementedError,
+      "The atom of type '%s' cannot be unpacked (missing __unpack__)",
+      Py_TYPE(self)->tp_name);
+    return NULL;
+  }
+  if (PyArg_ParseTupleAndKeywords(args, kw, "O", kwlist, &context) < 0) {
+    return NULL;
+  }
+  return self->ob_unpack((PyObject*)self, context);
+}
+
+static PyObject*
+cp_atom_unpack_many(CpAtomObject* self, PyObject* args, PyObject* kw)
+{
+
+  static char* kwlist[] = { "context", "lengthinfo", NULL };
+  PyObject *context = NULL, *lengthinfo = NULL;
+  if (self->ob_unpack_many == NULL) {
+    PyErr_Format(
+      PyExc_NotImplementedError,
+      "The atom of type '%s' cannot be unpacked (missing __unpack_many__)",
+      Py_TYPE(self)->tp_name);
+    return NULL;
+  }
+
+  if (PyArg_ParseTupleAndKeywords(
+        args, kw, "OO", kwlist, &context, &lengthinfo) < 0) {
+    return NULL;
+  }
+  return self->ob_unpack_many((PyObject*)self, context, lengthinfo);
+}
+
+static PyObject*
+cp_atom_type(CpAtomObject* self)
+{
+  return self->ob_type ? self->ob_type(_Cp_CAST(PyObject*, self))
+                       : Py_NotImplemented;
+}
+
+static PyObject*
+cp_atom_bits(CpAtomObject* self)
+{
+  return self->ob_bits ? self->ob_bits(_Cp_CAST(PyObject*, self))
+                       : Py_NotImplemented;
+}
+
+static PyObject*
+cp_atom_size(CpAtomObject* self, PyObject* args, PyObject* kw)
+{
+  static char* kwlist[] = { "context", NULL };
+  PyObject* context = NULL;
+
+  if (!self->ob_size) {
+    PyErr_Format(PyExc_NotImplementedError,
+                 "The atom of type '%s' has no size (missing __size__)",
+                 Py_TYPE(self)->tp_name);
+    return NULL;
+  }
+  if (PyArg_ParseTupleAndKeywords(args, kw, "O", kwlist, &context) < 0) {
+    return NULL;
+  }
+  if (Py_IsNone(context)) {
+    PyErr_SetString(PyExc_ValueError, "context must be set!");
+    return NULL;
+  }
+  return self->ob_size((PyObject*)self, context);
+}
+
+/* docs */
+
+PyDoc_STRVAR(cp_atom__doc__, "\
+Atom()\n\
+--\n\
+\n\
+Base class for C atom types.");
+
+static PyMethodDef CpCAtom_Methods[] = {
+  { "__pack__", (PyCFunction)cp_atom_pack, METH_VARARGS | METH_KEYWORDS, NULL },
+  { "__pack_many__",
+    (PyCFunction)cp_atom_pack_many,
+    METH_VARARGS | METH_KEYWORDS,
+    NULL },
+  { "__unpack__",
+    (PyCFunction)cp_atom_unpack,
+    METH_VARARGS | METH_KEYWORDS,
+    NULL },
+  { "__unpack_many__",
+    (PyCFunction)cp_atom_unpack_many,
+    METH_VARARGS | METH_KEYWORDS,
+    NULL },
+  { "__type__", (PyCFunction)cp_atom_type, METH_NOARGS, NULL },
+  { "__size__", (PyCFunction)cp_atom_size, METH_VARARGS | METH_KEYWORDS, NULL },
+  { "__bits__", (PyCFunction)cp_atom_bits, METH_NOARGS, NULL },
+  { NULL } /* Sentinel */
+};
+
+PyTypeObject CpAtom_Type = {
+  PyVarObject_HEAD_INIT(NULL, 0) _Cp_NameStr(CpAtom_NAME),
+  .tp_basicsize = sizeof(CpAtomObject),
+  .tp_dealloc = (destructor)cp_atom_dealloc,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = cp_atom__doc__,
+  .tp_methods = CpCAtom_Methods,
+  .tp_init = (initproc)cp_atom_init,
+  .tp_new = (newfunc)cp_atom_new,
+};
+
+/* init */
+int
+cp_atom__mod_types()
+{
+  CpModule_SetupType(&CpAtom_Type, -1);
+  return 0;
+}
+
+void
+cp_atom__mod_clear(PyObject* m, _modulestate* state)
+{
+}
+
+int
+cp_atom__mod_init(PyObject* m, _modulestate* state)
+{
+  CpModule_AddObject(CpAtom_NAME, &CpAtom_Type, -1);
+  return 0;
+}

--- a/src/ccaterpillar/lengthinfo.c
+++ b/src/ccaterpillar/lengthinfo.c
@@ -1,0 +1,88 @@
+#include "caterpillar/caterpillar.h"
+#include "private.h"
+
+#include <structmember.h>
+
+// ------------------------------------------------------------------------------
+// length info
+
+static PyObject*
+cp_lengthinfo_new(PyTypeObject* type, PyObject* args, PyObject* kw)
+{
+  CpLengthInfoObject* self = NULL;
+  if ((self = _Cp_CAST(CpLengthInfoObject*, type->tp_alloc(type, 0)), !self)) {
+    return NULL;
+  }
+
+  self->m_greedy = 0;
+  self->m_length = 0;
+  return _Cp_CAST(PyObject*, self);
+}
+
+static void
+cp_lengthinfo_dealloc(CpLengthInfoObject* self)
+{
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static int
+cp_lengthinfo_init(CpLengthInfoObject* self, PyObject* args, PyObject* kw)
+{
+  static char* kwlist[] = { "length", "greedy", NULL };
+  Py_ssize_t length = 0;
+  int greedy = 0;
+
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "|np", kwlist, &length, &greedy)) {
+    return -1;
+  }
+
+  self->m_length = length;
+  self->m_greedy = greedy;
+  return 0;
+}
+
+static PyObject*
+cp_lengthinfo_repr(CpLengthInfoObject* self)
+{
+  if (self->m_greedy) {
+    return PyUnicode_FromString("<LengthInfo [greedy]>");
+  }
+  return PyUnicode_FromFormat("<LengthInfo [%d]>", self->m_length);
+}
+
+static PyMemberDef CpLengthInfo_Members[] = {
+  { "length", T_PYSSIZET, offsetof(CpLengthInfoObject, m_length), 0, NULL },
+  { "greedy", T_BOOL, offsetof(CpLengthInfoObject, m_greedy), 0, NULL },
+  { NULL } /* Sentinel */
+};
+
+PyTypeObject CpLengthInfo_Type = {
+  PyVarObject_HEAD_INIT(NULL, 0) _Cp_NameStr(CpLengthInfo_NAME),
+  .tp_basicsize = sizeof(CpLengthInfoObject),
+  .tp_dealloc = (destructor)cp_lengthinfo_dealloc,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_new = (newfunc)cp_lengthinfo_new,
+  .tp_init = (initproc)cp_lengthinfo_init,
+  .tp_repr = (reprfunc)cp_lengthinfo_repr,
+  .tp_doc = NULL,
+};
+
+/* init */
+int
+cp_lengthinfo__mod_types()
+{
+  CpModule_SetupType(&CpLengthInfo_Type, -1);
+  return 0;
+}
+
+void
+cp_lengthinfo__mod_clear(PyObject* m, _modulestate* state)
+{
+}
+
+int
+cp_lengthinfo__mod_init(PyObject* m, _modulestate* state)
+{
+  CpModule_AddObject(CpLengthInfo_NAME, &CpLengthInfo_Type, -1);
+  return 0;
+}

--- a/src/ccaterpillar/module.c.in
+++ b/src/ccaterpillar/module.c.in
@@ -16,9 +16,7 @@ cp_module_clear(PyObject* m)
   _modulestate* state = get_module_state(m);
   if (state) {
     /* clear default arch and endian */
-    cp_arch__mod_clear(m, state);
-    cp_option__mod_clear(m, state);
-    cp_context__mod_clear(m, state);
+    %s
   }
   return 0;
 }
@@ -30,18 +28,12 @@ cp_module_free(void* m)
 }
 
 /* module def */
-static PyMethodDef _module_methods[] = { { NULL } };
-
 PyModuleDef CpModule = {
-  PyModuleDef_HEAD_INIT, /* m_base */
-  "caterpillar._C",      /* m_name */
-  NULL,                  /* m_doc */
-  sizeof(_modulestate),  /* m_size */
-  _module_methods,       /* m_methods */
-  NULL,                  /* m_slots */
-  NULL,                  /* m_traverse */
-  cp_module_clear,       /* m_clear */
-  cp_module_free         /* m_free */
+  PyModuleDef_HEAD_INIT,          /* m_base */
+  .m_name = "caterpillar._C",     /* m_name */
+  .m_size = sizeof(_modulestate), /* m_size */
+  .m_clear = cp_module_clear,     /* m_clear */
+  .m_free = cp_module_free        /* m_free */
 };
 
 /* module init */
@@ -64,9 +56,7 @@ PyInit__C(void)
   if (name##__mod_init(m, state) < 0)                                          \
   return NULL
 
-  SETUP_TYPES(cp_context);
-  SETUP_TYPES(cp_arch);
-  SETUP_TYPES(cp_option);
+  %s
 
   if (cp_context__mod_types() < 0)
     return NULL;
@@ -79,9 +69,7 @@ PyInit__C(void)
   /* setup state */
   _modulestate* state = get_module_state(m);
 
-  ADD_OBJECTS(cp_context);
-  ADD_OBJECTS(cp_arch);
-  ADD_OBJECTS(cp_option);
+  %s
 
   /*Export API table*/
   PyObject* c_api = PyCapsule_New((void*)Cp_API, NULL, NULL);

--- a/src/ccaterpillar/private.h.in
+++ b/src/ccaterpillar/private.h.in
@@ -35,7 +35,7 @@
   }                                                                            \
   return 0;
 
-#define CpModule_AddObject(name, value, ret)                                  \
+#define CpModule_AddObject(name, value, ret)                                   \
   Py_INCREF(value);                                                            \
   if (PyModule_AddObject(m, name, (PyObject*)(value)) < 0) {                   \
     Py_DECREF(value);                                                          \
@@ -102,9 +102,9 @@
 #define _CpDef_ModFn(name)                                                     \
   int name##__mod_init(PyObject* m, _modulestate* state);                      \
   void name##__mod_clear(PyObject* m, _modulestate* state);                    \
-  int name##__mod_types(void);
+  int name##__mod_types(void)
 
-_CpDef_ModFn(cp_context) _CpDef_ModFn(cp_arch) _CpDef_ModFn(cp_option)
+%s
 
 #undef _CpDef_ModFn
 

--- a/test/_C/test_atom.py
+++ b/test/_C/test_atom.py
@@ -1,0 +1,36 @@
+# pylint: disable=unused-import, no-name-in-module
+import pytest
+import caterpillar
+
+if caterpillar.native_support():
+    from caterpillar._C import Atom, LengthInfo
+
+    def testc_atom_init():
+        # instantiation will work but is useless
+        atom = Atom()
+
+        with pytest.raises(TypeError):
+            _ = Atom(a=1)
+
+    def testc_atom_protocol():
+        # each method will raise NotImplementedError or
+        # return NotImplemented
+        atom = Atom()
+
+        with pytest.raises(NotImplementedError):
+            atom.__unpack__(None)
+
+        with pytest.raises(NotImplementedError):
+            atom.__pack__(None, None)
+
+        with pytest.raises(NotImplementedError):
+            atom.__unpack_many__(None, None)
+
+        with pytest.raises(NotImplementedError):
+            atom.__pack_many__(None, None, None)
+
+        with pytest.raises(NotImplementedError):
+            atom.__size__(None)
+
+        assert atom.__type__() is NotImplemented
+        assert atom.__bits__() is NotImplemented


### PR DESCRIPTION
+ Update `abc.pyi` to include missing protocols
+ Add `Atom` to CAPI (previously catom)
+ Add `LengthInfo` to CAPI (previously lengthinfo)

*Note: Atom and LengthInfo don't use the CAPI specific prefix `c_`, because they don't have a python counterpart*