### PR TITLE
[DEV] (2.6.0-rc) CAPI Builtin-Atoms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ python_add_library(
   src/ccaterpillar/context.c
   src/ccaterpillar/atom.c
   src/ccaterpillar/lengthinfo.c
+  src/ccaterpillar/shared.c
+  src/ccaterpillar/atoms/builtin/builtin.c
+  src/ccaterpillar/atoms/builtin/repeated.c
+  src/ccaterpillar/atoms/builtin/switch.c
+  src/ccaterpillar/atoms/builtin/conditional.c
 
   WITH_SOABI
 )

--- a/src/capi.dat
+++ b/src/capi.dat
@@ -23,56 +23,96 @@
 #       Defines the source file (relative to this file) that contains the
 #       function definitions. IGNORE indicates this file won't be used to
 #       generate the module file.
+#
+# The INDEX will be represented by a '+' for add using current running
+# number or '-' to exclude this element from the shared CAPI.
 
 src:ccaterpillar/arch.c
 src:ccaterpillar/context.c
 src:ccaterpillar/atom.c
 src:ccaterpillar/option.c
 src:ccaterpillar/lengthinfo.c
+src:ccaterpillar/shared.c:IGNORE
+src:ccaterpillar/atoms/builtin/builtin.c
+src:ccaterpillar/atoms/builtin/repeated.c
+src:ccaterpillar/atoms/builtin/switch.c
+src:ccaterpillar/atoms/builtin/conditional.c
 
 # First index is reserved for the global module reference
-obj:0:CpModule:PyModuleDef
+obj:+:CpModule:PyModuleDef
+obj:+:Cp_ArrayFactory:PyObject*
+obj:+:Cp_ContextFactory:PyObject*
+obj:+:CpExc_Stop:PyObject*
+obj:+:Cp_DefaultOption:PyObject*
 
 type:-:_modulestate:_modulestate:-
+type:+:_archobj:CpArchObject:c_Arch
+type:+:_atomobj:CpAtomObject:Atom
+type:+:_builtinatomobj:CpBuiltinAtomObject:BuiltinAtom
+type:+:_contextobj:CpContextObject:c_Context
+type:+:_endianobj:CpEndianObject:c_Endian
+type:+:_lengthinfoobj:CpLengthInfoObject:LengthInfo
+type:+:_optionobj:CpOptionObject:c_Option
+type:+:_repeatedatomobj:CpRepeatedAtomObject:Repeated
+type:+:_switchatomobj:CpSwitchAtomObject:Switch
+type:+:_conditionalatomobj:CpConditionalAtomObject:Conditional
 
-# CpArch API
-type:1:_archobj:CpArchObject:c_Arch
-func:-:CpArch_New:PyObject*:+1
+func:+:Cp_HasStruct:int:null
+func:+:Cp_GetStructNoCheck:PyObject*:+1
+func:+:Cp_GetStruct:PyObject*:+1
 func:-:CpArch_GetName:PyObject*:+1
 func:-:CpArch_GetPtrSize:int:null
-
-# CpEndian API
-type:2:_endianobj:CpEndianObject:c_Endian
-func:-:CpEndian_GetName:PyObject*:+1
+func:-:CpArch_New:PyObject*:+1
+func:+:CpAtom_Pack:int:null
+func:+:CpAtom_PackMany:int:null
+func:+:CpAtom_Size:PyObject*:+1
+func:+:CpAtom_Unpack:PyObject*:+1
+func:+:CpAtom_UnpackMany:PyObject*:+1
+func:+:CpAtom_BitsOf:PyObject*:+1
+func:+:CpAtom_TypeOf:PyObject*:+1
+func:-:CpBuiltinAtom_New:PyObject*:+1
+func:-:CpContext_GetDict:PyObject*:+1
+func:+:CpContext_GenericGetAttr:PyObject*:+1
+func:+:CpContext_GenericGetAttrString:PyObject*:+1
+func:+:CpContext_GenericSetAttr:int:null
+func:+:CpContext_GenericSetAttrString:int:null
+func:+:CpContext_GetRoot:PyObject*:+1
+func:-:CpContext_New:PyObject*:+1
 func:-:CpEndian_GetId:char:null
-func:3:CpEndian_IsLittleEndian:int:null
-
-# CpOption API
-type:4:_optionobj:CpOptionObject:c_Option
+func:+:CpEndian_IsLittleEndian:int:null
+func:-:CpEndian_GetName:PyObject*:+1
+func:-:CpLengthInfo_IsGreedy:int:null
+func:-:CpLengthInfo_Length:int:null
+func:-:CpLengthInfo_LengthAsLong:PyObject*:+1
+func:-:CpLengthInfo_New:PyObject*:+1
+func:-:CpLengthInfo_SetGreedy:void:null
+func:-:CpLengthInfo_SetLength:int:null
+func:-:CpLengthInfo_SetLengthFromLong:int:null
+func:-:CpOption_GetName:PyObject*:+1
+func:-:CpOption_GetValue:PyObject*:+1
 func:-:CpOption_New:PyObject*:+1
 func:-:CpOption_SetValue:int:null
-func:-:CpOption_GetValue:PyObject*:+1
-func:-:CpOption_GetName:PyObject*:+1
-
-# CpContext API
-type:5:_contextobj:CpContextObject:c_Context
-func:6:CpContext_GenericGetAttr:PyObject*:+1
-func:7:CpContext_GenericGetAttrString:PyObject*:+1
-func:8:CpContext_GetRoot:PyObject*:+1
-func:-:CpContext_New:PyObject*:+1
-func:-:CpContext_GetDict:PyObject*:+1
-func:9:CpContext_GenericSetAttr:int:null
-func:10:CpContext_GenericSetAttrString:int:null
-
-# CpAtom API
-type:11:_atomobj:CpAtomObject:Atom
-
-# Length info
-type:20:_lengthinfoobj:CpLengthInfoObject:LengthInfo
-func:-:CpLengthInfo_New:PyObject*:+1
-func:-:CpLengthInfo_Length:int:null
-func:-:CpLengthInfo_IsGreedy:int:null
-func:-:CpLengthInfo_LengthAsLong:PyObject*:+1
-func:-:CpLengthInfo_SetLengthFromLong:int:null
-func:-:CpLengthInfo_SetLength:int:null
-func:-:CpLengthInfo_SetGreedy:void:null
+func:-:CpRepeatedAtom_GetLength:PyObject*:+1
+func:-:CpRepeatedAtom_New:PyObject*:+1
+func:+:CpRepeatedAtom_Pack:int:null
+func:+:CpRepeatedAtom_Size:PyObject*:+1
+func:+:CpRepeatedAtom_TypeOf:PyObject*:+1
+func:+:CpRepeatedAtom_Unpack:PyObject*:+1
+func:+:CpRepeatedAtom_Bits:PyObject*:+1
+func:-:CpRepeatedAtom_SetAtom:int:null
+func:-:CpRepeatedAtom_GetAtom:PyObject*:+1
+func:-:CpRepeatedAtom_SetLength:int:null
+func:+:Cp_FactoryNew:PyObject*:+1
+func:-:CpSwitchAtom_SetCases:int:null
+func:-:CpSwitchAtom_SetAtom:int:null
+func:+:CpSwitchAtom_EvalWithContext:PyObject*:+1
+func:+:CpSwitchAtom_Unpack:PyObject*:+1
+func:-:CpSwitchAtom_New:PyObject*:+1
+func:+:CpSwitchAtom_TypeOf:PyObject*:+1
+func:+:CpSwitchAtom_Pack:PyObject*:+1
+func:-:CpConditionalAtom_GetAtom:PyObject*:+1
+func:-:CpConditionalAtom_GetCondition:PyObject*:+1
+func:-:CpConditionalAtom_New:PyObject*:+1
+func:+:CpConditionalAtom_Enabled:int:null
+func:-:CpConditionalAtom_SetAtom:int:null
+func:-:CpConditionalAtom_SetCondition:int:null

--- a/src/caterpillar/include/caterpillar/atom.h
+++ b/src/caterpillar/include/caterpillar/atom.h
@@ -210,4 +210,5 @@ CpAtom_New(void)
 }
 
 
+
 #endif // ATOMOBJ_H

--- a/src/caterpillar/include/caterpillar/atoms/builtin/builtin.h
+++ b/src/caterpillar/include/caterpillar/atoms/builtin/builtin.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) MatrixEditor 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef CP_BUILTIN_H
+#define CP_BUILTIN_H
+
+#include "caterpillar/caterpillarapi.h"
+#include "caterpillar/atom.h"
+
+// Builtin atoms are similar to the Python class FieldMixin but implement
+// all parts of a field separately. For instance, the builtin atom for a
+// sequence only implements the sequence part.
+struct _builtinatomobj
+{
+  // this class does not implement any struct-like methods but implements
+  // special operators used by caterpillar.
+  CpAtom_HEAD;
+};
+
+#define CpBuiltinAtom_CheckExact(op) Py_IS_TYPE((op), &CpBuiltinAtom_Type)
+#define CpBuiltinAtom_Check(op) PyObject_TypeCheck((op), &CpBuiltinAtom_Type)
+#define CpBuiltinAtom_HEAD CpBuiltinAtomObject ob_base;
+#define CpBuiltinAtom_ATOM(self) (self)->ob_base.ob_base
+
+static inline PyObject *
+CpBuiltinAtom_New(void)
+{
+  return CpObject_CreateNoArgs(&CpBuiltinAtom_Type);
+}
+
+#endif

--- a/src/caterpillar/include/caterpillar/atoms/builtin/conditional.h
+++ b/src/caterpillar/include/caterpillar/atoms/builtin/conditional.h
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) MatrixEditor 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef CP_BUILTIN_CONDITIONAL_H
+#define CP_BUILTIN_CONDITIONAL_H
+
+#include "caterpillar/atoms/builtin/builtin.h"
+#include "caterpillar/caterpillarapi.h"
+
+//------------------------------------------------------------------------------
+// Conditional
+//------------------------------------------------------------------------------
+struct _conditionalatomobj
+{
+  CpBuiltinAtom_HEAD;
+
+  /// Stores a reference to the actual parsing struct that will be used
+  /// to parse or build our data. This attribute is never null.
+  PyObject* m_atom;
+
+  /// A constant or dynamic value to represent the condition.
+  PyObject* m_condition;
+};
+
+#define CpConditionalAtom_CheckExact(op)                                       \
+  Py_IS_TYPE((op), &CpConditionalAtom_Type)
+#define CpConditionalAtom_Check(op)                                            \
+  PyObject_TypeCheck((op), &CpConditionalAtom_Type)
+
+static inline PyObject*
+CpConditionalAtom_GetAtom(PyObject* pObj)
+{
+  return Py_XNewRef(_Cp_CAST(CpConditionalAtomObject*, pObj)->m_atom);
+}
+
+static inline PyObject*
+CpConditionalAtom_GetCondition(PyObject* pObj)
+{
+  return Py_XNewRef(_Cp_CAST(CpConditionalAtomObject*, pObj)->m_condition);
+}
+
+static inline PyObject*
+CpConditionalAtom_New(PyObject* atom, PyObject* condition)
+{
+  return CpObject_Create(&CpConditionalAtom_Type, "OO", atom, condition);
+}
+
+static inline int
+CpConditionalAtom_SetAtom(PyObject* pObj, PyObject* pAtom)
+{
+  CpConditionalAtomObject* self = _Cp_CAST(CpConditionalAtomObject*, pObj);
+  if (!pAtom) {
+    PyErr_SetString(PyExc_ValueError, "Atom cannot be null");
+  }
+
+  Py_XSETREF(self->m_atom, Py_NewRef(pAtom));
+  return 0;
+}
+
+static inline int
+CpConditionalAtom_SetCondition(PyObject* pObj, PyObject* pCondition)
+{
+  CpConditionalAtomObject* self = _Cp_CAST(CpConditionalAtomObject*, pObj);
+  if (!pCondition) {
+    PyErr_SetString(PyExc_ValueError, "Condition cannot be null");
+  }
+
+  Py_XSETREF(self->m_condition, Py_NewRef(pCondition));
+  return 0;
+}
+
+#endif

--- a/src/caterpillar/include/caterpillar/atoms/builtin/repeated.h
+++ b/src/caterpillar/include/caterpillar/atoms/builtin/repeated.h
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) MatrixEditor 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef CP_BUILTIN_REPEATED_H
+#define CP_BUILTIN_REPEATED_H
+
+#include "caterpillar/atoms/builtin/builtin.h"
+#include "caterpillar/caterpillarapi.h"
+
+struct _repeatedatomobj
+{
+  CpBuiltinAtom_HEAD;
+
+  /// Stores a reference to the actual parsing struct that will be used
+  /// to parse or build our data. This attribute is never null.
+  PyObject* m_atom;
+
+  /// A constant or dynamic value to represent the amount of structs. Zero
+  /// indicates there are no sequence types associated with this field.
+  PyObject* m_length;
+};
+
+#define CpRepeatedAtom_CheckExact(op) Py_IS_TYPE((op), &CpRepeatedAtom_Type)
+#define CpRepeatedAtom_Check(op) PyObject_TypeCheck((op), &CpRepeatedAtom_Type)
+
+static inline PyObject*
+CpRepeatedAtom_New(PyObject* atom, PyObject* length)
+{
+  return CpObject_Create(&CpRepeatedAtom_Type, "OO", atom, length);
+}
+
+static inline PyObject*
+CpRepeatedAtom_GetAtom(PyObject* pObj)
+{
+  return Py_XNewRef(_Cp_CAST(CpRepeatedAtomObject*, pObj)->m_atom);
+}
+
+static inline PyObject*
+CpRepeatedAtom_GetLength(PyObject* pObj, PyObject* pContext)
+{
+  PyObject* nResult = NULL;
+  CpRepeatedAtomObject* self = _Cp_CAST(CpRepeatedAtomObject*, pObj);
+  if (PyCallable_Check(self->m_length) && pContext) {
+    if ((nResult = PyObject_CallOneArg(self->m_length, pContext), !nResult))
+      return NULL;
+  } else {
+    nResult = Py_NewRef(self->m_length);
+  }
+  return nResult;
+}
+
+static inline int
+CpRepeatedAtom_SetAtom(PyObject* pObj, PyObject* pAtom)
+{
+  CpRepeatedAtomObject* self = _Cp_CAST(CpRepeatedAtomObject*, pObj);
+  if (!pAtom) {
+    PyErr_SetString(PyExc_ValueError, "Atom cannot be null");
+  }
+
+  Py_XSETREF(self->m_atom, Py_NewRef(pAtom));
+  return 0;
+}
+
+static inline int
+CpRepeatedAtom_SetLength(PyObject* pObj, PyObject* pLength)
+{
+  CpRepeatedAtomObject* self = _Cp_CAST(CpRepeatedAtomObject*, pObj);
+  if (!pLength) {
+    PyErr_SetString(PyExc_ValueError, "Length cannot be null");
+  }
+
+  Py_XSETREF(self->m_length, Py_NewRef(pLength));
+  return 0;
+}
+
+#endif

--- a/src/caterpillar/include/caterpillar/atoms/builtin/switch.h
+++ b/src/caterpillar/include/caterpillar/atoms/builtin/switch.h
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) MatrixEditor 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef CP_BUILTIN_SWITCH_H
+#define CP_BUILTIN_SWITCH_H
+
+#include "caterpillar/atoms/builtin/builtin.h"
+#include "caterpillar/caterpillarapi.h"
+
+//------------------------------------------------------------------------------
+// Switch
+//------------------------------------------------------------------------------
+struct _switchatomobj
+{
+  CpBuiltinAtom_HEAD;
+
+  /// Stores a reference to the actual parsing struct that will be used
+  /// to parse or build our data. This attribute is never null.
+  PyObject* m_atom;
+
+  // A dictionary or dynamic value to represent the cases.
+  PyObject* m_cases;
+
+  // pre-computed state of the atom object
+  int s_callable;
+};
+
+#define CpSwitchAtom_CheckExact(op) Py_IS_TYPE((op), &CpSwitchAtom_Type)
+#define CpSwitchAtom_Check(op) PyObject_TypeCheck((op), &CpSwitchAtom_Type)
+
+static inline PyObject*
+CpSwitchAtom_New(PyObject* atom, PyObject* cases)
+{
+  return CpObject_Create(&CpSwitchAtom_Type, "OO", atom, cases);
+}
+
+static inline PyObject*
+CpSwitchAtom_GetAtom(PyObject* pObj)
+{
+  return Py_XNewRef(_Cp_CAST(CpSwitchAtomObject*, pObj)->m_atom);
+}
+
+static inline PyObject*
+CpSwitchAtom_GetCases(PyObject* pObj)
+{
+  return Py_XNewRef(_Cp_CAST(CpSwitchAtomObject*, pObj)->m_cases);
+}
+
+static inline int
+CpSwitchAtom_IsContextLambda(PyObject* pObj)
+{
+  return _Cp_CAST(CpSwitchAtomObject*, pObj)->s_callable;
+}
+
+static inline int
+CpSwitchAtom_SetCases(PyObject* pObj, PyObject* pCases)
+{
+  CpSwitchAtomObject* self = _Cp_CAST(CpSwitchAtomObject*, pObj);
+  if (!pCases) {
+    PyErr_SetString(PyExc_ValueError, "Cases cannot be null");
+  }
+
+  Py_XSETREF(self->m_cases, Py_NewRef(pCases));
+  self->s_callable = PyCallable_Check(self->m_cases);
+  return 0;
+}
+
+static inline int
+CpSwitchAtom_SetAtom(PyObject* pObj, PyObject* pAtom)
+{
+  CpSwitchAtomObject* self = _Cp_CAST(CpSwitchAtomObject*, pObj);
+  if (!pAtom) {
+    PyErr_SetString(PyExc_ValueError, "Atom cannot be null");
+  }
+
+  Py_XSETREF(self->m_atom, Py_NewRef(pAtom));
+  return 0;
+}
+
+#endif

--- a/src/caterpillar/include/caterpillar/caterpillar.h
+++ b/src/caterpillar/include/caterpillar/caterpillar.h
@@ -7,8 +7,15 @@
 #include "caterpillar/arch.h"
 #include "caterpillar/atom.h"
 #include "caterpillar/context.h"
+#include "caterpillar/lengthinfo.h"
 #include "caterpillar/module.h"
 #include "caterpillar/option.h"
-#include "caterpillar/lengthinfo.h"
+
+#include "caterpillar/atoms/builtin/builtin.h"
+#include "caterpillar/atoms/builtin/repeated.h"
+#include "caterpillar/atoms/builtin/switch.h"
+#include "caterpillar/atoms/builtin/conditional.h"
+
+
 
 #endif

--- a/src/caterpillar/include/caterpillar/context.h
+++ b/src/caterpillar/include/caterpillar/context.h
@@ -64,10 +64,29 @@ CpContext_GetDict(PyObject* obj)
   return Py_NewRef(&_Cp_CAST(CpContextObject*, obj)->m_dict);
 }
 
-inline static PyObject*
-CpContext_New()
+#define CpContext_New() Cp_FactoryNew(Cp_ContextFactory)
+
+static inline int
+CpContext_SETITEM(PyObject* self, PyObject* key, PyObject* value)
 {
-  return CpObject_CreateNoArgs(&CpContext_Type);
+  return PyDict_SetItem(
+    (PyObject*)&_Cp_CAST(CpContextObject*, self)->m_dict, key, value);
 }
 
+static inline int
+CpContext_COPYITEM(PyObject* pContext, PyObject* pSrc, PyObject* pKey)
+{
+  PyObject* nValue = PyObject_GetItem(pSrc, pKey);
+  if (!nValue) {
+    return -1;
+  }
+  return CpContext_SETITEM(pContext, pKey, nValue);
+}
+
+static inline PyObject*
+CpContext_ITEM(PyObject* self, PyObject* key)
+{
+  return PyDict_GetItem((PyObject*)&_Cp_CAST(CpContextObject*, self)->m_dict,
+                        key);
+}
 #endif

--- a/src/caterpillar/include/caterpillar/lengthinfo.h
+++ b/src/caterpillar/include/caterpillar/lengthinfo.h
@@ -33,7 +33,7 @@ struct _lengthinfoobj
 static inline PyObject*
 CpLengthInfo_New(Py_ssize_t pLength, int pGreedy)
 {
-  return CpObject_Create(&CpLengthInfo_Type, "np", pLength, pGreedy);
+  return CpObject_Create(&CpLengthInfo_Type, "ni", pLength, pGreedy);
 }
 
 static inline Py_ssize_t

--- a/src/caterpillar/include/caterpillar/module.h
+++ b/src/caterpillar/include/caterpillar/module.h
@@ -38,6 +38,25 @@ struct _modulestate
   PyObject* str__path_sep;
   PyObject* str__context_root;
   PyObject* str__fn_rsplit;
+  PyObject* str__pack;
+  PyObject* str__pack_many;
+  PyObject* str__unpack;
+  PyObject* str__unpack_many;
+  PyObject* str__type;
+  PyObject* str__size;
+  PyObject* str__bits;
+  PyObject* str__context_parent;
+  PyObject* str__context_io;
+  PyObject* str__context_length;
+  PyObject* str__context_index;
+  PyObject* str__context_path;
+  PyObject* str__context_obj;
+  PyObject* str__context_is_seq;
+  PyObject* str__context_field;
+  PyObject* str__start;
+  PyObject* str__value;
+  PyObject* str__context_list;
+  PyObject* str__struct;
 };
 
 /**

--- a/src/caterpillar/model/_struct.py
+++ b/src/caterpillar/model/_struct.py
@@ -461,6 +461,7 @@ def pack_into(
         _path="<root>",
         _pos=0,
         _offsets=offsets,
+        _is_seq=False,
         mode=MODE_PACK,
         **kwds,
     )

--- a/src/ccaterpillar/atoms/builtin/builtin.c
+++ b/src/ccaterpillar/atoms/builtin/builtin.c
@@ -1,0 +1,94 @@
+#include "../../private.h"
+#include "caterpillar/caterpillar.h"
+
+#include <structmember.h>
+
+PyObject*
+cp_builtinatom_new(PyTypeObject* type, PyObject* args, PyObject* kw)
+{
+  CpBuiltinAtomObject* self;
+  if ((self = (CpBuiltinAtomObject*)type->tp_alloc(type, 0), !self)) {
+    return NULL;
+  }
+
+  Cp_ATOM(self).ob_bits = NULL;
+  Cp_ATOM(self).ob_pack = NULL;
+  Cp_ATOM(self).ob_pack_many = NULL;
+  Cp_ATOM(self).ob_unpack = NULL;
+  Cp_ATOM(self).ob_unpack_many = NULL;
+  Cp_ATOM(self).ob_type = NULL;
+  Cp_ATOM(self).ob_size = NULL;
+  return _Cp_CAST(PyObject*, self);
+}
+
+void
+cp_builtinatom_dealloc(CpBuiltinAtomObject* self)
+{
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject*
+cp_builtinatom_repr(CpBuiltinAtomObject* self)
+{
+  return PyUnicode_FromString("<BuiltinAtom>");
+}
+
+static int
+cp_builtinatom_init(CpBuiltinAtomObject* self, PyObject* args, PyObject* kw)
+{
+  _Cp_InitNoArgs(BuiltinAtoms, args, kw);
+}
+
+static PyObject*
+cp_builtinatom_getitem(PyObject* self, PyObject* pLength)
+{
+  return CpRepeatedAtom_New(self, pLength);
+}
+
+static PyObject*
+cp_builtinatom_as_number_rshift(PyObject* self, PyObject* pCases)
+{
+  return CpSwitchAtom_New(self, pCases);
+}
+
+PyMappingMethods CpBuiltinAtom_MappingMethods = {
+  .mp_subscript = (binaryfunc)cp_builtinatom_getitem,
+};
+
+PyNumberMethods CpBuiltinAtom_NumberMethods = {
+  .nb_rshift = (binaryfunc)cp_builtinatom_as_number_rshift,
+};
+
+PyTypeObject CpBuiltinAtom_Type = {
+  PyVarObject_HEAD_INIT(NULL, 0) _Cp_NameStr(CpBuiltinAtom_NAME),
+  .tp_basicsize = sizeof(CpBuiltinAtomObject),
+  .tp_dealloc = (destructor)cp_builtinatom_dealloc,
+  .tp_init = (initproc)cp_builtinatom_init,
+  .tp_new = (newfunc)cp_builtinatom_new,
+  .tp_repr = (reprfunc)cp_builtinatom_repr,
+  .tp_as_mapping = &CpBuiltinAtom_MappingMethods,
+  .tp_as_number = &CpBuiltinAtom_NumberMethods,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = NULL,
+};
+
+/* init */
+int
+cp_builtin__mod_types()
+{
+  CpBuiltinAtom_Type.tp_base = &CpAtom_Type;
+  CpModule_SetupType(&CpBuiltinAtom_Type, -1);
+  return 0;
+}
+
+void
+cp_builtin__mod_clear(PyObject* m, _modulestate* state)
+{
+}
+
+int
+cp_builtin__mod_init(PyObject* m, _modulestate* state)
+{
+  CpModule_AddObject(CpBuiltinAtom_NAME, &CpBuiltinAtom_Type, -1);
+  return 0;
+}

--- a/src/ccaterpillar/atoms/builtin/conditional.c
+++ b/src/ccaterpillar/atoms/builtin/conditional.c
@@ -1,0 +1,230 @@
+#include "../../private.h"
+#include "caterpillar/caterpillar.h"
+
+#include <structmember.h>
+
+static PyObject*
+cp_conditionalatom_new(PyTypeObject* type, PyObject* args, PyObject* kw)
+{
+  CpConditionalAtomObject* self = NULL;
+  _Cp_AssignCheck(
+    self, (CpConditionalAtomObject*)type->tp_alloc(type, 0), error);
+
+  CpBuiltinAtom_ATOM(self).ob_bits = NULL;
+  CpBuiltinAtom_ATOM(self).ob_pack = NULL;
+  CpBuiltinAtom_ATOM(self).ob_pack_many = NULL;
+  CpBuiltinAtom_ATOM(self).ob_unpack = NULL;
+  CpBuiltinAtom_ATOM(self).ob_unpack_many = NULL;
+  CpBuiltinAtom_ATOM(self).ob_type = NULL;
+  CpBuiltinAtom_ATOM(self).ob_size = NULL;
+  self->m_atom = NULL;
+  self->m_condition = NULL;
+
+  return _Cp_CAST(PyObject*, self);
+error:
+  return NULL;
+}
+
+static void
+cp_conditionalatom_dealloc(CpConditionalAtomObject* self)
+{
+  Py_CLEAR(self->m_atom);
+  Py_CLEAR(self->m_condition);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static int
+cp_conditionalatom_init(CpConditionalAtomObject* self,
+                        PyObject* args,
+                        PyObject* kw)
+{
+  static char* kwlist[] = { "atom", "condition", NULL };
+  PyObject *atom = NULL, *condition = NULL;
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "OO", kwlist, &atom, &condition)) {
+    return -1;
+  }
+  _Cp_SetObj(self->m_atom, atom);
+  _Cp_SetObj(self->m_condition, condition);
+  return 0;
+}
+
+_CpEndian_ImplSetByteorder(CpConditionalAtomObject,
+                           conditionalatom,
+                           self->m_atom);
+
+static PyObject*
+cp_conditionalatom_repr(CpConditionalAtomObject* self)
+{
+  return PyUnicode_FromFormat("%R if (%R)", self->m_atom, self->m_condition);
+}
+
+static PyObject*
+cp_conditionalatom_eval_with_context(PyObject* self,
+                                     PyObject* args,
+                                     PyObject* kw)
+{
+  static char* kwlist[] = { "context", NULL };
+  PyObject* context = NULL;
+  int result = 0;
+
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "O", kwlist, &context)) {
+    return NULL;
+  }
+
+  if ((result = CpConditionalAtom_Enabled(self, context), result < 0)) {
+    return NULL;
+  }
+
+  return result ? Py_True : Py_False;
+}
+
+/*Public API*/
+
+/*CpAPI*/
+int
+CpConditionalAtom_Enabled(PyObject* pAtom, PyObject* pContext)
+{
+  PyObject* nContextLambdaResult = NULL;
+  int enabled = false;
+  CpConditionalAtomObject* self = _Cp_CAST(CpConditionalAtomObject*, pAtom);
+
+  if (!self->m_condition) {
+    enabled = true;
+  } else if (PyCallable_Check(self->m_condition)) {
+    _Cp_AssignCheck(nContextLambdaResult,
+                    PyObject_CallOneArg(self->m_condition, pContext),
+                    error);
+
+    enabled = PyObject_IsTrue(nContextLambdaResult);
+  } else {
+    enabled = PyObject_IsTrue(self->m_condition);
+  }
+  goto success;
+
+error:
+  enabled = -1;
+
+success:
+  Py_XDECREF(nContextLambdaResult);
+  return enabled;
+}
+
+/*CpAPI*/
+int
+CpConditionalAtom_Pack(PyObject* pAtom, PyObject* pObj, PyObject* pContext)
+{
+  int enabled = 0;
+  if ((enabled = CpConditionalAtom_Enabled(pAtom, pContext)) < 0) {
+    return -1;
+  }
+
+  return enabled
+           ? CpAtom_Pack(_Cp_CAST(CpConditionalAtomObject*, pAtom)->m_atom,
+                         pObj,
+                         pContext)
+           : 0;
+}
+
+/*CpAPI*/
+PyObject*
+CpConditionalAtom_Unpack(PyObject* pAtom, PyObject* pContext)
+{
+  int enabled = 0;
+  if ((enabled = CpConditionalAtom_Enabled(pAtom, pContext)) < 0) {
+    return NULL;
+  }
+
+  return enabled
+           ? CpAtom_Unpack(_Cp_CAST(CpConditionalAtomObject*, pAtom)->m_atom,
+                           pContext)
+           : Py_None;
+}
+
+/*CpAPI*/
+PyObject*
+CpConditionalAtom_TypeOf(PyObject* pAtom)
+{
+  PyObject *nResult = NULL, *nAtomType = NULL;
+  CpConditionalAtomObject* self = _Cp_CAST(CpConditionalAtomObject*, pAtom);
+
+  _Cp_AssignCheck(nAtomType, CpAtom_TypeOf(self->m_atom), error);
+  _Cp_AssignCheck(nResult, PyNumber_Or(nAtomType, Py_None), error);
+
+error:
+  Py_CLEAR(nResult);
+
+success:
+  Py_XDECREF(nAtomType);
+  return nResult;
+}
+
+/*CpAPI*/
+PyObject*
+CpConditionalAtom_Size(PyObject* pAtom, PyObject* pContext)
+{
+  PyObject* nResult = NULL;
+  int enabled = 0;
+
+  if ((enabled = CpConditionalAtom_Enabled(pAtom, pContext)) >= 0) {
+    nResult = enabled
+                ? CpAtom_Size(_Cp_CAST(CpConditionalAtomObject*, pAtom)->m_atom,
+                              pContext)
+                : PyLong_FromLong(0);
+  }
+
+  return nResult;
+}
+
+/*type*/
+static PyMemberDef CpConditionAtom_Members[] = {
+  { "condition",
+    T_OBJECT,
+    offsetof(CpConditionalAtomObject, m_condition),
+    READONLY },
+  { "atom", T_OBJECT, offsetof(CpConditionalAtomObject, m_atom), READONLY },
+  { NULL }
+};
+
+static PyMethodDef CpConditionAtom_Methods[] = {
+  _CpEndian_ImplSetByteorder_MethDef(conditionalatom, NULL),
+  {
+    "is_enabled",
+    (PyCFunction)cp_conditionalatom_eval_with_context,
+    METH_VARARGS | METH_KEYWORDS,
+  },
+  { NULL }
+};
+
+PyTypeObject CpConditionalAtom_Type = {
+  PyVarObject_HEAD_INIT(NULL, 0) _Cp_NameStr(CpConditionalAtom_NAME),
+  .tp_basicsize = sizeof(CpConditionalAtomObject),
+  .tp_dealloc = (destructor)cp_conditionalatom_dealloc,
+  .tp_init = (initproc)cp_conditionalatom_init,
+  .tp_members = CpConditionAtom_Members,
+  .tp_methods = CpConditionAtom_Methods,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = NULL,
+  .tp_new = (newfunc)cp_conditionalatom_new,
+  .tp_repr = (reprfunc)cp_conditionalatom_repr,
+};
+
+/*init*/
+int
+cp_conditional__mod_types()
+{
+  CpConditionalAtom_Type.tp_base = &CpBuiltinAtom_Type;
+  CpModule_SetupType(&CpConditionalAtom_Type, -1);
+  return 0;
+}
+
+void
+cp_conditional__mod_clear(PyObject* m, _modulestate* state)
+{
+}
+
+int
+cp_conditional__mod_init(PyObject* m, _modulestate* state)
+{
+  CpModule_AddObject(CpConditionalAtom_NAME, &CpConditionalAtom_Type, -1);
+  return 0;
+}

--- a/src/ccaterpillar/atoms/builtin/repeated.c
+++ b/src/ccaterpillar/atoms/builtin/repeated.c
@@ -1,0 +1,645 @@
+#include "../../private.h"
+#include "caterpillar/caterpillar.h"
+
+#include <structmember.h>
+
+static PyObject*
+cp_repeatedatom_new(PyTypeObject* type, PyObject* args, PyObject* kw)
+{
+  CpRepeatedAtomObject* self;
+  if ((self = (CpRepeatedAtomObject*)type->tp_alloc(type, 0), !self)) {
+    return NULL;
+  }
+
+  CpBuiltinAtom_ATOM(self).ob_bits = CpRepeatedAtom_Bits;
+  CpBuiltinAtom_ATOM(self).ob_pack = CpRepeatedAtom_Pack;
+  CpBuiltinAtom_ATOM(self).ob_pack_many = NULL;
+  CpBuiltinAtom_ATOM(self).ob_unpack = CpRepeatedAtom_Unpack;
+  CpBuiltinAtom_ATOM(self).ob_unpack_many = NULL;
+  CpBuiltinAtom_ATOM(self).ob_type = CpRepeatedAtom_TypeOf;
+  CpBuiltinAtom_ATOM(self).ob_size = CpRepeatedAtom_Size;
+  return _Cp_CAST(PyObject*, self);
+}
+
+static void
+cp_repeatedatom_dealloc(CpRepeatedAtomObject* self)
+{
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static int
+cp_repeatedatom_init(CpRepeatedAtomObject* self, PyObject* args, PyObject* kw)
+{
+  static char* kwlist[] = { "atom", "length", NULL };
+  PyObject *atom = NULL, *length = NULL;
+
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "OO", kwlist, &atom, &length)) {
+    return -1;
+  }
+  _Cp_SetObj(self->m_atom, atom);
+  _Cp_SetObj(self->m_length, length);
+
+  return 0;
+}
+
+static PyObject*
+cp_repeatedatom__repr__(CpRepeatedAtomObject* self)
+{
+  return PyUnicode_FromFormat("%R[%R]", self->m_atom, self->m_length);
+}
+
+_CpEndian_ImplSetByteorder(CpRepeatedAtomObject, repeatedatom, self->m_atom);
+
+/* Private API */
+static int
+_CpPack_EvalLength(PyObject* pContext,
+                   PyObject* pLength,
+                   Py_ssize_t pSize,
+                   int* pGreedy,
+                   Py_ssize_t* pEvaluatedLength)
+{
+  PyObject *nStart = NULL, *nSizeObj = NULL;
+  int result = 0;
+  _modulestate* state = get_global_module_state();
+
+  if (Py_Is(pLength, &_Py_EllipsisObject)) {
+    // greedy
+    *pGreedy = true;
+    *pEvaluatedLength = pSize;
+    goto success;
+  }
+
+  if (PySlice_Check(pLength)) {
+    // prefixed length
+    *pGreedy = false;
+    nStart = PyObject_GetAttr(pLength, state->str__start);
+    if (!nStart) {
+      goto error;
+    }
+
+    if (Py_IsNone(nStart)) {
+      PyErr_SetString(
+        PyExc_ValueError,
+        "Prefixed length is not supported for this atom! (start=None)");
+      goto error;
+    }
+
+    nSizeObj = PyLong_FromSsize_t(pSize);
+    if (!nSizeObj) {
+      goto error;
+    }
+
+    result = CpAtom_Pack(nStart, nSizeObj, pContext);
+    if (result < 0) {
+      goto error;
+    }
+    *pEvaluatedLength = pSize;
+    goto success;
+  }
+
+  if (PyLong_Check(pLength)) {
+    *pGreedy = false;
+    *pEvaluatedLength = PyLong_AsSsize_t(pLength);
+    if (*pEvaluatedLength < 0) {
+      PyErr_Clear();
+      PyErr_SetString(PyExc_ValueError,
+                      "Negative length is not supported for this atom!");
+      goto error;
+    }
+
+    if (*pEvaluatedLength != pSize) {
+      PyErr_Format(PyExc_ValueError,
+                   "given length %d does not match sequence size %d",
+                   *pEvaluatedLength,
+                   pSize);
+      goto error;
+    }
+    goto success;
+  }
+
+  PyErr_SetString(PyExc_ValueError,
+                  "length is not an integer or slice nor is greedy!");
+
+error:
+  result = -1;
+
+success:
+  Py_XDECREF(nStart);
+  Py_XDECREF(nSizeObj);
+  return result;
+}
+
+static int
+_CpUnpack_EvalLength(PyObject* pContext,
+                     PyObject* pSeqLength,
+                     int* pGreedy,
+                     Py_ssize_t* pEvaluatedLength)
+{
+  PyObject *nStart = NULL, *nSizeObj = NULL;
+  int result = 0;
+  _modulestate* state = get_global_module_state();
+
+  *pEvaluatedLength = 0;
+  *pGreedy = false;
+  // 1. Case: greedy length
+  //    We have to set the context variables accordingly.
+  if (Py_IS_TYPE(pSeqLength, &PyEllipsis_Type)) {
+    *pGreedy = true;
+    *pEvaluatedLength = -1;
+    goto success;
+  }
+
+  // 2. Case: length is a slice (prefixed type)
+  //    As this is a special type, we have to first parse the length
+  //    using the given start atom.
+  if (PySlice_Check(pSeqLength)) {
+    *pGreedy = false;
+    if ((nStart = PyObject_GetAttr(pSeqLength, state->str__start), !nStart)) {
+      goto error;
+    }
+
+    if (Py_IsNone(nStart)) {
+      PyErr_SetString(PyExc_ValueError,
+                      "Prefixed length is not supported for this atom!");
+      goto error;
+    }
+
+    // revisit: set is_seq to false
+    CpContext_SETITEM(pContext, state->str__context_is_seq, Py_False);
+    nSizeObj = CpAtom_Unpack(nStart, pContext);
+    CpContext_SETITEM(pContext, state->str__context_is_seq, Py_True);
+    if (!nSizeObj) {
+      goto error;
+    }
+
+    *pEvaluatedLength = PyLong_AsSsize_t(nSizeObj);
+    if (*pEvaluatedLength < 0) {
+      PyErr_Clear();
+      PyErr_SetString(PyExc_ValueError,
+                      "Negative length is not supported for this atom!");
+      goto error;
+    }
+
+    goto success;
+  }
+
+  if (PyLong_Check(pSeqLength)) {
+    *pGreedy = false;
+    *pEvaluatedLength = PyLong_AsSsize_t(pSeqLength);
+    if (*pEvaluatedLength < 0) {
+      PyErr_Clear();
+      PyErr_SetString(PyExc_ValueError,
+                      "Negative length is not supported for this atom!");
+      goto error;
+    }
+    goto success;
+  }
+
+  PyErr_SetString(PyExc_ValueError,
+                  "length is not an integer or slice nor is greedy!");
+
+error:
+  result = -1;
+
+success:
+  Py_XDECREF(nStart);
+  Py_XDECREF(nSizeObj);
+  return result;
+}
+
+/* Public API */
+
+/*CpAPI*/
+PyObject*
+CpRepeatedAtom_TypeOf(PyObject* pAtom)
+{
+  PyObject *nResult = NULL, *nAtomType = NULL;
+
+  _Cp_AssignCheck(nAtomType,
+                  CpAtom_TypeOf(_Cp_CAST(CpRepeatedAtomObject*, pAtom)->m_atom),
+                  error);
+
+  _Cp_AssignCheck(
+    nResult, PyObject_GetItem((PyObject*)&PyList_Type, nAtomType), error);
+
+  goto success;
+
+error:
+  nResult = NULL;
+
+success:
+  Py_XDECREF(nAtomType);
+  return nResult;
+}
+
+/*CpAPI*/
+PyObject*
+CpRepeatedAtom_Bits(PyObject* pAtom)
+{
+  PyObject *nResult = NULL, *nLength = NULL, *nAtomBits = NULL,
+           *nBitsSize = PyLong_FromLong(8);
+  if (!nBitsSize) {
+    goto error;
+  }
+  _Cp_AssignCheck(nLength, CpRepeatedAtom_GetLength(pAtom, NULL), error);
+  if (!PyNumber_Check(nLength)) {
+    PyErr_SetString(PyExc_ValueError, "length is not a number!");
+    goto error;
+  }
+
+  _Cp_AssignCheck(nAtomBits,
+                  CpAtom_BitsOf(_Cp_CAST(CpRepeatedAtomObject*, pAtom)->m_atom),
+                  error);
+  _Cp_AssignCheck(nResult, PyNumber_Multiply(nLength, nAtomBits), error);
+  Py_XSETREF(nResult, PyNumber_Multiply(nResult, nBitsSize));
+  if (!nResult) {
+    goto error;
+  }
+  goto success;
+
+error:
+  Py_XSETREF(nResult, NULL);
+
+success:
+  Py_XDECREF(nLength);
+  Py_XDECREF(nAtomBits);
+  Py_XDECREF(nBitsSize);
+  return nResult;
+}
+
+/*CpAPI*/
+PyObject*
+CpRepeatedAtom_Size(PyObject* pAtom, PyObject* pContext)
+{
+  PyObject *nLength = NULL, *nAtomSize = NULL, *nResult = NULL;
+  _Cp_AssignCheck(nLength, CpRepeatedAtom_GetLength(pAtom, pContext), error);
+  _Cp_AssignCheck(
+    nAtomSize,
+    CpAtom_Size(_Cp_CAST(CpRepeatedAtomObject*, pAtom)->m_atom, pContext),
+    error);
+
+  if (!PyNumber_Check(nAtomSize)) {
+    PyErr_SetString(PyExc_ValueError, "atom size is not a number!");
+    goto error;
+  }
+  if (!PyNumber_Check(nLength)) {
+    PyErr_SetString(PyExc_ValueError, "length is not a constant!");
+    goto error;
+  }
+
+  if ((nResult = PyNumber_Multiply(nLength, nAtomSize), !nResult)) {
+    goto error;
+  }
+  goto success;
+
+error:
+  Py_XSETREF(nResult, NULL);
+
+success:
+  Py_XDECREF(nLength);
+  Py_XDECREF(nAtomSize);
+  return nResult;
+}
+
+/*CpAPI*/
+int
+CpRepeatedAtom_Pack(PyObject* pAtom, PyObject* pObj, PyObject* pContext)
+{
+  PyObject *nLengthInfo = NULL, *nLength = NULL, *nTmpObj = NULL,
+           *nResult = NULL, *nRaisedException = NULL, *nSeqContext = NULL,
+           *nBasePath = NULL, *nTmpPath = NULL, *nTmpIndex = NULL;
+  Py_ssize_t seqLength = 0, index = 0;
+  bool hasPackMany = false, isSeq = false;
+  int result = 0;
+  _modulestate* state = get_global_module_state();
+  CpRepeatedAtomObject* self = _Cp_CAST(CpRepeatedAtomObject*, pAtom);
+
+  hasPackMany = CpAtom_HasPackMany(self->m_atom);
+  isSeq = PySequence_Check(pObj);
+
+  // first, get the length of the input sequence
+  if (isSeq) {
+    if ((seqLength = PySequence_Length(pObj)) < 0) {
+      goto error;
+    }
+  } else {
+    PyErr_Format(PyExc_ValueError, "input object (%R) is not a sequence", pObj);
+    goto error;
+  }
+  _Cp_AssignCheck(nLength, CpRepeatedAtom_GetLength(pAtom, pContext), error);
+
+  if ((nLengthInfo = CpLengthInfo_New(seqLength, hasPackMany), !nLengthInfo)) {
+    goto error;
+  }
+
+  if (_CpPack_EvalLength(
+        pContext,
+        nLength,
+        seqLength,
+        &_Cp_CAST(CpLengthInfoObject*, nLengthInfo)->m_greedy,
+        &_Cp_CAST(CpLengthInfoObject*, nLengthInfo)->m_length) < 0) {
+    goto error;
+  }
+  if (hasPackMany) {
+    // class explicitly defines __pack_many__ -> use it
+    result = CpAtom_PackMany(self->m_atom, pObj, pContext, nLengthInfo);
+    if (result < 0 &&
+        (nRaisedException = PyErr_GetRaisedException(),
+         nRaisedException && PyErr_GivenExceptionMatches(
+                               nRaisedException, PyExc_NotImplementedError))) {
+      // Make sure this method continues to pack the given object
+      PyErr_Clear();
+    } else {
+      if (result < 0 && nRaisedException) {
+        // This call steals a reference to exc, which must be a valid exception.
+        PyErr_SetRaisedException(nRaisedException);
+        nRaisedException = NULL;
+      }
+      goto success;
+    }
+  }
+
+  if (CpLengthInfo_IsGreedy(nLengthInfo)) {
+    if (CpLengthInfo_SetLength(nLengthInfo, seqLength) < 0) {
+      goto error;
+    }
+  } else {
+    if (CpLengthInfo_Length(nLengthInfo) != seqLength) {
+      PyErr_Format(PyExc_ValueError,
+                   "given length %d does not match sequence size %d",
+                   CpLengthInfo_Length(nLengthInfo),
+                   seqLength);
+      goto error;
+    }
+  }
+
+  // create context compatible to Python implementation
+  _Cp_AssignCheck(nSeqContext, CpContext_New(), error);
+  // _root
+  _Cp_AssignCheck(nTmpObj, CpContext_GetRoot(pContext), error);
+  if (CpContext_SETITEM(nSeqContext, state->str__context_root, nTmpObj) < 0)
+    goto error;
+
+  // _parent
+  if (CpContext_SETITEM(
+        nSeqContext, state->str__context_parent, Py_NewRef(pContext)) < 0)
+    goto error;
+
+  // _io
+  if (CpContext_COPYITEM(nSeqContext, pContext, state->str__context_io) < 0) {
+    goto error;
+  }
+
+  // _length
+  if (CpContext_SETITEM(nSeqContext,
+                        state->str__context_length,
+                        CpLengthInfo_LengthAsLong(nLengthInfo)) < 0)
+    goto error;
+
+  // _field
+  if (CpContext_COPYITEM(nSeqContext, pContext, state->str__context_field) < 0)
+    goto error;
+
+  // _is_seq
+  CpContext_SETITEM(nSeqContext, state->str__context_is_seq, Py_False);
+
+  // main loop
+  if ((nBasePath = CpContext_ITEM(pContext, state->str__context_path),
+       !nBasePath)) {
+    goto error;
+  }
+
+  for (index = 0; index < CpLengthInfo_Length(nLengthInfo); ++index) {
+    Py_XSETREF(nTmpObj, PySequence_ITEM(pObj, index));
+    if (!nTmpObj) {
+      goto error;
+    }
+
+    Py_XSETREF(nTmpPath, PyUnicode_FromFormat("%S.%d", nBasePath, index));
+    if (!nTmpPath) {
+      goto error;
+    }
+
+    Py_XSETREF(nTmpIndex, PyLong_FromSsize_t(index));
+    if (!nTmpIndex) {
+      goto error;
+    }
+
+    CpContext_SETITEM(nSeqContext, state->str__context_index, nTmpIndex);
+    CpContext_SETITEM(nSeqContext, state->str__context_path, nTmpPath);
+    CpContext_SETITEM(nSeqContext, state->str__context_obj, nTmpObj);
+    if (CpAtom_Pack(self->m_atom, nTmpObj, nSeqContext) < 0) {
+      if (nRaisedException = PyErr_GetRaisedException(),
+          nRaisedException &&
+            PyErr_GivenExceptionMatches(nRaisedException, CpExc_Stop)) {
+        // Make sure this method continues to pack the given object
+        PyErr_Clear();
+        break;
+      } else {
+        if (nRaisedException) {
+          // This call steals a reference to exc, which must be a valid
+          // exception.
+          PyErr_SetRaisedException(nRaisedException);
+          nRaisedException = NULL;
+        }
+        goto error;
+      }
+    }
+  }
+
+  goto success;
+
+error:
+  result = -1;
+
+success:
+  Py_XDECREF(nLengthInfo);
+  Py_XDECREF(nLength);
+  Py_XDECREF(nTmpObj);
+  Py_XDECREF(nResult);
+  Py_XDECREF(nRaisedException);
+  Py_XDECREF(nSeqContext);
+  Py_XDECREF(nTmpIndex);
+  Py_XDECREF(nTmpPath);
+  Py_XDECREF(nBasePath);
+  return result;
+}
+
+/*CpAPI*/
+PyObject*
+CpRepeatedAtom_Unpack(PyObject* pAtom, PyObject* pContext)
+{
+  PyObject *nResult = NULL, *nTmpObj = NULL, *nSeqContext = NULL,
+           *nRaisedException = NULL, *nBasePath = NULL, *nTmpPath = NULL,
+           *nLength = NULL, *nLengthInfo = NULL, *nSeq = NULL,
+           *nTmpIndex = NULL;
+  _modulestate* state = get_global_module_state();
+  Py_ssize_t index = 0;
+  bool hasUnpackMany = false;
+  CpRepeatedAtomObject* self = _Cp_CAST(CpRepeatedAtomObject*, pAtom);
+
+  hasUnpackMany = CpAtom_HasPackMany(self->m_atom);
+  _Cp_AssignCheck(nLength, CpRepeatedAtom_GetLength(pAtom, pContext), error);
+  _Cp_AssignCheck(nLengthInfo, CpLengthInfo_New(0, false), error);
+  if (_CpUnpack_EvalLength(
+        pContext,
+        nLength,
+        &_Cp_CAST(CpLengthInfoObject*, nLengthInfo)->m_greedy,
+        &_Cp_CAST(CpLengthInfoObject*, nLengthInfo)->m_length) < 0) {
+    goto error;
+  }
+
+  if (hasUnpackMany) {
+    nTmpObj = CpAtom_UnpackMany(self->m_atom, pContext, nLengthInfo);
+    if (!nTmpObj &&
+        (nRaisedException = PyErr_GetRaisedException(),
+         nRaisedException && PyErr_GivenExceptionMatches(
+                               nRaisedException, PyExc_NotImplementedError))) {
+      PyErr_Clear();
+    } else {
+      if (nRaisedException) {
+        // This call steals a reference to exc, which must be a valid
+        // exception.
+        PyErr_SetRaisedException(nRaisedException);
+        nRaisedException = NULL;
+      }
+      goto success;
+    }
+  }
+  _Cp_AssignCheck(nSeqContext, CpContext_New(), error);
+  _Cp_AssignCheck(nSeq, PyList_New(0), error);
+  Py_XSETREF(nTmpObj, NULL);
+  Py_XSETREF(nResult, Py_NewRef(nSeq));
+
+  // base path
+  _Cp_AssignCheck(
+    nBasePath, CpContext_ITEM(pContext, state->str__context_path), error);
+
+  // _root
+  CpContext_SETITEM(
+    nSeqContext, state->str__context_root, CpContext_GetRoot(pContext));
+  // _parent
+  CpContext_SETITEM(nSeqContext, state->str__context_parent, pContext);
+  // _length
+  CpContext_SETITEM(nSeqContext, state->str__context_length, nLength);
+  // _obj
+  CpContext_COPYITEM(nSeqContext, pContext, state->str__context_obj);
+  // _is_seq
+  CpContext_SETITEM(nSeqContext, state->str__context_is_seq, Py_False);
+  // _field
+  if (CpContext_COPYITEM(nSeqContext, pContext, state->str__context_field) <
+      0) {
+    // optional
+    PyErr_Clear();
+  }
+  // _io
+  CpContext_COPYITEM(nSeqContext, pContext, state->str__context_io);
+  // _lst
+  CpContext_SETITEM(nSeqContext, state->str__context_list, nSeq);
+
+  while (CpLengthInfo_IsGreedy(nLengthInfo) ||
+         index < CpLengthInfo_Length(nLengthInfo)) {
+
+    // set new path and index
+    Py_XSETREF(nTmpPath, PyUnicode_FromFormat("%S.%d", nBasePath, index));
+    Py_XSETREF(nTmpIndex, PyLong_FromSsize_t(index));
+    if (!nTmpPath || !nTmpIndex) {
+      goto error;
+    }
+
+    CpContext_SETITEM(nSeqContext, state->str__context_path, nTmpPath);
+    CpContext_SETITEM(nSeqContext, state->str__context_index, nTmpIndex);
+    Py_XSETREF(nTmpObj, CpAtom_Unpack(self->m_atom, nSeqContext));
+    if (!nTmpObj &&
+        (nRaisedException = PyErr_GetRaisedException(),
+         nRaisedException &&
+           (PyErr_GivenExceptionMatches(nRaisedException, CpExc_Stop) ||
+            CpLengthInfo_IsGreedy(nLengthInfo)))) {
+      // Make sure this method continues to pack the given object
+      PyErr_Clear();
+      break;
+    } else {
+      if (nRaisedException) {
+        // This call steals a reference to exc, which must be a valid
+        // exception.
+        PyErr_SetRaisedException(nRaisedException);
+        nRaisedException = NULL;
+      }
+      if (!nTmpObj)
+        goto error;
+    }
+
+    if (PyList_Append(nSeq, nTmpObj) < 0) {
+      goto error;
+    }
+    ++index;
+  }
+
+  // REVISIT: array factory
+  goto success;
+
+error:
+  Py_XSETREF(nResult, NULL);
+
+success:
+  Py_XDECREF(nLength);
+  Py_XDECREF(nLengthInfo);
+  Py_XDECREF(nSeqContext);
+  Py_XDECREF(nBasePath);
+  Py_XDECREF(nTmpPath);
+  Py_XDECREF(nTmpIndex);
+  Py_XDECREF(nTmpObj);
+  Py_XDECREF(nRaisedException);
+  // Py_XDECREF(nSeq); // new ref is stored in nResult
+  return nResult;
+}
+
+/* type */
+static PyMemberDef CpRepeatedAtom_Members[] = {
+  { "length", T_OBJECT, offsetof(CpRepeatedAtomObject, m_length), READONLY },
+  { "atom", T_OBJECT, offsetof(CpRepeatedAtomObject, m_atom), READONLY },
+  { NULL }
+};
+
+static PyMethodDef CpRepeatedAtom_Methods[] = {
+  _CpEndian_ImplSetByteorder_MethDef(repeatedatom, NULL),
+  {
+    NULL,
+  }
+};
+
+PyTypeObject CpRepeatedAtom_Type = {
+  PyVarObject_HEAD_INIT(NULL, 0) _Cp_NameStr(CpRepeatedAtom_NAME),
+  .tp_basicsize = sizeof(CpRepeatedAtomObject),
+  .tp_dealloc = (destructor)cp_repeatedatom_dealloc,
+  .tp_repr = (reprfunc)cp_repeatedatom__repr__,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = NULL,
+  .tp_new = (newfunc)cp_repeatedatom_new,
+  .tp_init = (initproc)cp_repeatedatom_init,
+  .tp_members = CpRepeatedAtom_Members,
+  .tp_methods = CpRepeatedAtom_Methods,
+};
+
+/* init */
+int
+cp_repeated__mod_init(PyObject* m, _modulestate* state)
+{
+  CpModule_AddObject(CpRepeatedAtom_NAME, &CpRepeatedAtom_Type, -1);
+  _CACHED_STRING(state, str__start, "start", -1);
+  return 0;
+}
+
+int
+cp_repeated__mod_types()
+{
+  CpRepeatedAtom_Type.tp_base = &CpBuiltinAtom_Type;
+  CpModule_SetupType(&CpRepeatedAtom_Type, -1);
+  return 0;
+}
+
+void
+cp_repeated__mod_clear(PyObject* m, _modulestate* state)
+{
+  Py_CLEAR(state->str__start);
+}

--- a/src/ccaterpillar/atoms/builtin/switch.c
+++ b/src/ccaterpillar/atoms/builtin/switch.c
@@ -1,0 +1,272 @@
+#include "../../private.h"
+#include "caterpillar/caterpillar.h"
+
+#include <structmember.h>
+
+static PyObject*
+_Cp_EvalSwitchCases(PyObject* pValue, PyObject* pCases, PyObject* pContext);
+
+static PyObject*
+cp_switchatom_new(PyTypeObject* type, PyObject* args, PyObject* kw)
+{
+  CpSwitchAtomObject* self = NULL;
+  _Cp_AssignCheck(self, (CpSwitchAtomObject*)type->tp_alloc(type, 0), error);
+
+  CpBuiltinAtom_ATOM(self).ob_bits = NULL;
+  CpBuiltinAtom_ATOM(self).ob_pack = CpSwitchAtom_Pack;
+  CpBuiltinAtom_ATOM(self).ob_pack_many = NULL;
+  CpBuiltinAtom_ATOM(self).ob_unpack = CpSwitchAtom_Unpack;
+  CpBuiltinAtom_ATOM(self).ob_unpack_many = NULL;
+  CpBuiltinAtom_ATOM(self).ob_type = CpSwitchAtom_TypeOf;
+  CpBuiltinAtom_ATOM(self).ob_size = NULL;
+  self->m_atom = NULL;
+  self->m_cases = NULL;
+  self->s_callable = false;
+  return _Cp_CAST(PyObject*, self);
+error:
+  return NULL;
+}
+
+static void
+cp_switchatom_dealloc(CpSwitchAtomObject* self)
+{
+  Py_CLEAR(self->m_atom);
+  Py_CLEAR(self->m_cases);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static int
+cp_switchatom_init(CpSwitchAtomObject* self, PyObject* args, PyObject* kw)
+{
+  static char* kwlist[] = { "atom", "cases", NULL };
+  PyObject *atom = NULL, *cases = NULL;
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "OO", kwlist, &atom, &cases)) {
+    return -1;
+  }
+  _Cp_SetObj(self->m_atom, atom);
+  _Cp_SetObj(self->m_cases, cases);
+  self->s_callable = PyCallable_Check(atom);
+  return 0;
+}
+
+_CpEndian_ImplSetByteorder(CpSwitchAtomObject, switchatom, self->m_atom);
+
+static PyObject*
+cp_switchatom_repr(CpSwitchAtomObject* self)
+{
+  return PyUnicode_FromFormat("<switch %R >> %R>", self->m_atom, self->m_cases);
+}
+
+static PyObject*
+cp_switchatom_eval_with_context(CpSwitchAtomObject* self,
+                                PyObject* args,
+                                PyObject* kw)
+{
+  static char* kwlist[] = { "value", "context", NULL };
+  PyObject *value = NULL, *context = NULL;
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "OO", kwlist, &value, &context)) {
+    return NULL;
+  }
+  return _Cp_EvalSwitchCases(value, self->m_cases, context);
+}
+
+/*Private API*/
+static inline PyObject*
+_Cp_EvalSwitchCases(PyObject* pValue, PyObject* pCases, PyObject* pContext)
+{
+  PyObject* nResult = NULL;
+
+  if (PyCallable_Check(pCases)) {
+    _Cp_AssignCheck(
+      nResult,
+      PyObject_CallFunctionObjArgs(pCases, pValue, pContext, NULL),
+      error);
+  } else {
+    nResult = PyObject_GetItem(pCases, pValue);
+    if (!nResult) {
+      PyErr_Clear();
+      // try and search for default case
+      if ((nResult = PyObject_GetItem(pCases, Cp_DefaultOption), !nResult)) {
+        PyErr_Clear();
+        PyErr_Format(
+          PyExc_ValueError,
+          "No case matching the given value %R and no default case defined",
+          pValue);
+        goto error;
+      }
+    }
+  }
+
+  Py_XSETREF(nResult, Cp_GetStruct(nResult));
+  return nResult;
+
+error:
+  return NULL;
+}
+
+/*Public API*/
+
+/*CpAPI*/
+PyObject*
+CpSwitchAtom_EvalWithContext(PyObject* pAtom,
+                             PyObject* pValue,
+                             PyObject* pContext)
+{
+  CpSwitchAtomObject* self = _Cp_CAST(CpSwitchAtomObject*, pAtom);
+  return _Cp_EvalSwitchCases(pValue, self->m_cases, pContext);
+}
+
+/*CpAPI*/
+PyObject*
+CpSwitchAtom_Unpack(PyObject* pAtom, PyObject* pContext)
+{
+  PyObject *nResult = NULL, *nValue = NULL, *nTargetAtom = NULL;
+  CpSwitchAtomObject* self = _Cp_CAST(CpSwitchAtomObject*, pAtom);
+
+  if (self->s_callable) {
+    _Cp_AssignCheck(nValue, PyObject_CallOneArg(self->m_atom, pContext), error);
+  } else {
+    _Cp_AssignCheck(nValue, CpAtom_Unpack(self->m_atom, pContext), error);
+  }
+
+  _Cp_AssignCheck(
+    nTargetAtom, _Cp_EvalSwitchCases(nValue, self->m_cases, pContext), error);
+
+  Py_XSETREF(nResult, CpAtom_Unpack(nTargetAtom, pContext));
+  goto success;
+
+error:
+  Py_XSETREF(nResult, NULL);
+
+success:
+  Py_XDECREF(nValue);
+  Py_XDECREF(nTargetAtom);
+  return nResult;
+}
+
+/*CpAPI*/
+int
+CpSwitchAtom_Pack(PyObject* pAtom, PyObject* pObj, PyObject* pContext)
+{
+  PyObject *nValue = NULL, *nTargetAtom = NULL;
+  int result = 0;
+  CpSwitchAtomObject* self = _Cp_CAST(CpSwitchAtomObject*, pAtom);
+
+  if (!self->s_callable) {
+    PyErr_SetString(
+      PyExc_TypeError,
+      ("Switch atom currently supports only callable atoms when used as a "
+       "condition to select the final atom to be used to pack the given "
+       "value."));
+    return -1;
+  }
+
+  _Cp_AssignCheck(nValue, PyObject_CallOneArg(self->m_atom, pContext), error);
+  _Cp_AssignCheck(
+    nTargetAtom, _Cp_EvalSwitchCases(nValue, self->m_cases, pContext), error);
+  result = CpAtom_Pack(nTargetAtom, pObj, pContext);
+  goto success;
+
+error:
+  result = -1;
+
+success:
+  Py_XDECREF(nValue);
+  Py_XDECREF(nTargetAtom);
+  return result;
+}
+
+/*CpAPI*/
+PyObject*
+CpSwitchAtom_TypeOf(PyObject* pAtom)
+{
+  PyObject *nResult = NULL, *nAtomType = NULL, *nCasesValues = NULL,
+           *bTmpObj = NULL, *nTmpAtomType = NULL, *nTmpAtom = NULL;
+  Py_ssize_t numCases = 0;
+  _modulestate* state = get_global_module_state();
+  CpSwitchAtomObject* self = _Cp_CAST(CpSwitchAtomObject*, pAtom);
+
+  // we don't know the type of dynamic switch atoms
+  if (!PyDict_Check(self->m_cases)) {
+    return Py_NewRef(&PyBaseObject_Type);
+  }
+
+  _Cp_AssignCheck(nResult, CpAtom_TypeOf(self->m_atom), error);
+  _Cp_AssignCheck(nCasesValues, PyDict_Values(self->m_cases), error);
+  numCases = PyList_Size(nCasesValues);
+  for (Py_ssize_t i = 0; i < numCases; i++) {
+    _Cp_AssignCheck(bTmpObj, PyList_GetItem(nCasesValues, i), error);
+    Py_XSETREF(nTmpAtom, Cp_GetStruct(bTmpObj));
+    if (!nTmpAtom) {
+      goto error;
+    }
+
+    Py_XSETREF(nTmpAtomType, CpAtom_TypeOf(nTmpAtom));
+    if (!nTmpAtomType) {
+      goto error;
+    }
+
+    Py_XSETREF(nResult, PyNumber_Or(nResult, nTmpAtomType));
+  }
+  goto success;
+
+error:
+  Py_XSETREF(nResult, NULL);
+
+success:
+  Py_XDECREF(nAtomType);
+  Py_XDECREF(nCasesValues);
+  return nResult;
+}
+
+/*type*/
+
+/* members */
+static PyMemberDef CpSwitchAtom_Members[] = {
+  { "cases", T_OBJECT, offsetof(CpSwitchAtomObject, m_cases), READONLY },
+  { "atom", T_OBJECT, offsetof(CpSwitchAtomObject, m_atom), READONLY },
+  { NULL }
+};
+
+static PyMethodDef CpSwitchAtom_Methods[] = {
+  _CpEndian_ImplSetByteorder_MethDef(switchatom, NULL),
+  { "eval_with_context",
+    (PyCFunction)cp_switchatom_eval_with_context,
+    METH_VARARGS | METH_KEYWORDS,
+    NULL },
+  { NULL }
+};
+
+PyTypeObject CpSwitchAtom_Type = {
+  PyVarObject_HEAD_INIT(NULL, 0) _Cp_NameStr(CpSwitchAtom_NAME),
+  .tp_basicsize = sizeof(CpSwitchAtomObject),
+  .tp_dealloc = (destructor)cp_switchatom_dealloc,
+  .tp_init = (initproc)cp_switchatom_init,
+  .tp_members = CpSwitchAtom_Members,
+  .tp_methods = CpSwitchAtom_Methods,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = NULL,
+  .tp_new = (newfunc)cp_switchatom_new,
+  .tp_repr = (reprfunc)cp_switchatom_repr,
+};
+
+/*init*/
+int
+cp_switch__mod_types()
+{
+  CpSwitchAtom_Type.tp_base = &CpBuiltinAtom_Type;
+  CpModule_SetupType(&CpSwitchAtom_Type, -1);
+  return 0;
+}
+
+void
+cp_switch__mod_clear(PyObject* m, _modulestate* state)
+{
+}
+
+int
+cp_switch__mod_init(PyObject* m, _modulestate* state)
+{
+  CpModule_AddObject(CpSwitchAtom_NAME, &CpSwitchAtom_Type, -1);
+  return 0;
+}

--- a/src/ccaterpillar/context.c
+++ b/src/ccaterpillar/context.c
@@ -208,7 +208,7 @@ CpContext_GetRoot(PyObject* pObj)
     PyObject_GetItem((PyObject*)&(_Cp_CAST(CpContextObject*, pObj))->m_dict,
                      state->str__context_root);
   if (nRoot)
-    return NULL;
+    return nRoot;
 
   PyErr_Clear();
   return Py_NewRef(pObj);
@@ -298,6 +298,7 @@ success:
   Py_XDECREF(nMaxSplit);
   return error;
 }
+
 /* docs */
 
 PyDoc_STRVAR(cp_context__doc__, "\
@@ -358,6 +359,16 @@ cp_context__mod_init(PyObject* m, _modulestate* state)
   _CACHED_STRING(state, str__path_sep, ".", -1);
   _CACHED_STRING(state, str__context_root, "_root", -1);
   _CACHED_STRING(state, str__fn_rsplit, "rsplit", -1);
+  _CACHED_STRING(state, str__context_parent, "_parent", -1);
+  _CACHED_STRING(state, str__context_io, "_io", -1);
+  _CACHED_STRING(state, str__context_length, "_length", -1);
+  _CACHED_STRING(state, str__context_index, "_index", -1);
+  _CACHED_STRING(state, str__context_path, "_path", -1);
+  _CACHED_STRING(state, str__context_obj, "_obj", -1);
+  _CACHED_STRING(state, str__context_is_seq, "_is_seq", -1);
+  _CACHED_STRING(state, str__context_field, "_field", -1);
+  _CACHED_STRING(state, str__value, "value", -1);
+  _CACHED_STRING(state, str__context_list, "_lst", -1);
 
   CpModule_AddObject(CpContext_NAME, &CpContext_Type, -1);
   return 0;
@@ -369,4 +380,14 @@ cp_context__mod_clear(PyObject* m, _modulestate* state)
   Py_CLEAR(state->str__path_sep);
   Py_CLEAR(state->str__context_root);
   Py_CLEAR(state->str__fn_rsplit);
+  Py_CLEAR(state->str__context_parent);
+  Py_CLEAR(state->str__context_io);
+  Py_CLEAR(state->str__context_length);
+  Py_CLEAR(state->str__context_index);
+  Py_CLEAR(state->str__context_path);
+  Py_CLEAR(state->str__context_obj);
+  Py_CLEAR(state->str__context_is_seq);
+  Py_CLEAR(state->str__context_field);
+  Py_CLEAR(state->str__value);
+  Py_CLEAR(state->str__context_list);
 }

--- a/src/ccaterpillar/lengthinfo.c
+++ b/src/ccaterpillar/lengthinfo.c
@@ -32,7 +32,7 @@ cp_lengthinfo_init(CpLengthInfoObject* self, PyObject* args, PyObject* kw)
   Py_ssize_t length = 0;
   int greedy = 0;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kw, "|np", kwlist, &length, &greedy)) {
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "|ni", kwlist, &length, &greedy)) {
     return -1;
   }
 

--- a/src/ccaterpillar/module.c.in
+++ b/src/ccaterpillar/module.c.in
@@ -16,6 +16,7 @@ cp_module_clear(PyObject* m)
   _modulestate* state = get_module_state(m);
   if (state) {
     /* clear default arch and endian */
+    shared__mod_clear(m, state);
     %s
   }
   return 0;
@@ -40,60 +41,61 @@ PyModuleDef CpModule = {
 PyMODINIT_FUNC
 PyInit__C(void)
 {
-  PyObject* m;
+  PyObject *m = NULL, *c_api = NULL, *nDict = NULL;
+  _modulestate* state = NULL;
+
   m = PyState_FindModule(&CpModule);
   if (m) {
-    Py_INCREF(m);
-    return m;
+    return Py_NewRef(m);
   }
 
   // type setup
 #define SETUP_TYPES(name)                                                      \
   if (name##__mod_types() < 0)                                                 \
-  return NULL
+    goto err;
 
 #define ADD_OBJECTS(name)                                                      \
   if (name##__mod_init(m, state) < 0)                                          \
-  return NULL
+    goto err;
 
   %s
-
-  if (cp_context__mod_types() < 0)
-    return NULL;
 
   m = PyModule_Create(&CpModule);
   if (!m) {
-    return NULL;
+    goto err;
   }
 
   /* setup state */
-  _modulestate* state = get_module_state(m);
+  state = get_module_state(m);
 
+  ADD_OBJECTS(shared);
   %s
 
   /*Export API table*/
-  PyObject* c_api = PyCapsule_New((void*)Cp_API, NULL, NULL);
+  c_api = PyCapsule_New((void*)Cp_API, NULL, NULL);
   if (c_api == NULL) {
     goto err;
   }
 
-  PyObject* d = PyModule_GetDict(m);
-  if (d == NULL) {
+  if ((nDict = PyDict_New(), !nDict)) {
     goto err;
   }
 
-  if (PyDict_SetItemString(d, "_C_API", c_api) < 0) {
+  if (PyDict_SetItemString(nDict, "_C_API", c_api) < 0) {
     goto err;
   }
-  Py_DECREF(c_api);
-  return m;
+  goto success;
 
 err:
   if (!PyErr_Occurred()) {
     PyErr_SetString(PyExc_RuntimeError, "cannot load caterpillar._C module.");
   }
-  Py_DECREF(m);
-  return NULL;
+  Py_XSETREF(m, NULL);
+
+success:
+  Py_XDECREF(nDict);
+  Py_XDECREF(c_api);
+  return m;
 
 #undef SETUP_TYPES
 #undef ADD_OBJECTS

--- a/src/ccaterpillar/private.h.in
+++ b/src/ccaterpillar/private.h.in
@@ -27,6 +27,11 @@
     Py_XSETREF(varname, Py_NewRef(value));                                     \
   }
 
+#define _Cp_AssignCheck(target, value, err_cond)                               \
+  if ((target = (value), !target)) {                                           \
+    goto err_cond;                                                             \
+  }
+
 #define _Cp_InitNoArgs(type, args, kw)                                         \
   if ((args && PyTuple_Size(args)) || (kw && PyDict_Size(kw))) {               \
     PyErr_SetString(PyExc_TypeError,                                           \
@@ -99,6 +104,9 @@
   _CACHED_STRING(state, attr, str, NULL)
 
 // private module initializer and finalizer
+int shared__mod_init(PyObject* m, _modulestate* state);
+void shared__mod_clear(PyObject* m, _modulestate* state);
+
 #define _CpDef_ModFn(name)                                                     \
   int name##__mod_init(PyObject* m, _modulestate* state);                      \
   void name##__mod_clear(PyObject* m, _modulestate* state);                    \

--- a/src/ccaterpillar/shared.c
+++ b/src/ccaterpillar/shared.c
@@ -1,0 +1,141 @@
+#include "caterpillar/caterpillar.h"
+#include "private.h"
+
+#include <structmember.h>
+
+// Factory types
+PyObject* Cp_ContextFactory = NULL;
+PyObject* Cp_ArrayFactory = NULL;
+PyObject* Cp_DefaultOption = NULL;
+
+// Exceptions
+PyObject* CpExc_Stop = NULL;
+
+/*CpAPI*/
+PyObject*
+Cp_FactoryNew(PyObject* pFactoryReference)
+{
+  _modulestate* state = get_global_module_state();
+  PyObject *nResult = NULL,
+           *nFactory = PyObject_GetAttr(pFactoryReference, state->str__value);
+  if (!nFactory) {
+    PyErr_Clear();
+    nResult = CpObject_CreateNoArgs(&CpContext_Type);
+  } else {
+    nResult = PyObject_CallNoArgs(nFactory);
+  }
+  return nResult;
+}
+
+/*CpAPI*/
+int
+Cp_HasStruct(PyObject* pObj)
+{
+  // native implementation
+  PyObject* nType = NULL;
+  int result = 0;
+  _modulestate* state = get_global_module_state();
+
+  if (PyType_Check(pObj)) {
+    nType = Py_NewRef(pObj);
+  } else {
+    _Cp_AssignCheck(nType, PyObject_Type(pObj), error);
+  }
+
+  result = PyObject_HasAttr(nType, state->str__struct);
+  goto success;
+
+error:
+  result = -1;
+
+success:
+  Py_XDECREF(nType);
+  return result;
+}
+
+/*CpAPI*/
+PyObject*
+Cp_GetStructNoCheck(PyObject* pObj)
+{
+  // native implementation
+  PyObject *nType = NULL, *nResult = NULL;
+  _modulestate* state = get_global_module_state();
+
+  if (PyType_Check(pObj)) {
+    nType = Py_NewRef(pObj);
+  } else {
+    _Cp_AssignCheck(nType, PyObject_Type(pObj), error);
+  }
+
+  _Cp_AssignCheck(nResult, PyObject_GetAttr(nType, state->str__struct), error);
+  goto success;
+
+error:
+  Py_XSETREF(nResult, NULL);
+
+success:
+  Py_XDECREF(nType);
+  return nResult;
+}
+
+/*CpAPI*/
+PyObject*
+Cp_GetStruct(PyObject* pObj)
+{
+  // native implementation
+  PyObject* nResult = NULL;
+
+  nResult = Cp_GetStructNoCheck(pObj);
+  if (!nResult) {
+    PyErr_Clear();
+    nResult = Py_NewRef(pObj);
+  }
+
+  return nResult;
+}
+
+/*init*/
+void
+shared__mod_clear(PyObject* m, _modulestate* state)
+{
+  Py_CLEAR(CpExc_Stop);
+  Py_CLEAR(Cp_ArrayFactory);
+  Py_CLEAR(Cp_ContextFactory);
+  Py_CLEAR(Cp_DefaultOption);
+}
+
+int
+shared__mod_init(PyObject* m, _modulestate* state)
+{
+#define _IMPORT_ATTR(ext_mod, attr, target)                                    \
+  if ((target = PyObject_GetAttrString((ext_mod), (attr)), !target)) {         \
+    goto err;                                                                  \
+  }
+
+  PyObject* nTmpMod = NULL;
+
+  _Cp_AssignCheck(nTmpMod, PyImport_ImportModule("caterpillar.exception"), err);
+  _IMPORT_ATTR(nTmpMod, "Stop", CpExc_Stop);
+  Py_CLEAR(nTmpMod);
+
+  // import shared options
+  _Cp_AssignCheck(nTmpMod, PyImport_ImportModule("caterpillar.options"), err);
+  _IMPORT_ATTR(nTmpMod, "O_ARRAY_FACTORY", Cp_ArrayFactory);
+  Py_CLEAR(nTmpMod);
+
+  _Cp_AssignCheck(nTmpMod, PyImport_ImportModule("caterpillar.context"), err);
+  _IMPORT_ATTR(nTmpMod, "O_CONTEXT_FACTORY", Cp_ContextFactory);
+  Py_CLEAR(nTmpMod);
+
+  _Cp_AssignCheck(
+    nTmpMod, PyImport_ImportModule("caterpillar.fields._base"), err);
+  _IMPORT_ATTR(nTmpMod, "DEFAULT_OPTION", Cp_DefaultOption);
+  Py_CLEAR(nTmpMod);
+
+  return 0;
+
+err:
+  return -1;
+
+#undef _IMPORT_ATTR
+}

--- a/src/code_gen/caterpillar_api.py
+++ b/src/code_gen/caterpillar_api.py
@@ -25,6 +25,8 @@ cp_type_api = {}
 cp_api_src = []
 cp_func_api = {}  # <name>: <index> <<-->> <name>: (rtype, [args])
 
+global_index = 0
+
 for line in CAPI_PATH.read_text("utf-8").splitlines():
     if line.startswith("#"):
         continue
@@ -39,6 +41,9 @@ for line in CAPI_PATH.read_text("utf-8").splitlines():
             # obj:INDEX:NAME:TYPE
             #   Defines a C API object.
             index, name, type_ = parts
+            if index != "-":
+                index = global_index
+                global_index += 1
             cp_type_api[name] = (int(index), type_ if type_ != "-" else "PyTypeObject")
 
         case "type":
@@ -46,8 +51,11 @@ for line in CAPI_PATH.read_text("utf-8").splitlines():
             #   Defines a C API type for a C structure. The index is optional and
             #   the CAPI_TYPE will be inferred as PyTypeObject if none set
             index, struct_name, typedef_name, c_api_type = parts
+
             cp_types[struct_name] = typedef_name
             if index != "-":
+                index = global_index
+                global_index += 1
                 if typedef_name.endswith("Object"):
                     typedef_name = typedef_name[:-6] + "_Type"
                 cp_type_api[typedef_name] = (
@@ -70,6 +78,8 @@ for line in CAPI_PATH.read_text("utf-8").splitlines():
             #   source set of this file.
             index, name, *_ = parts
             if index != "-":
+                index = global_index
+                global_index += 1
                 cp_func_api[name] = int(index)
 
 

--- a/src/code_gen/genapi.py
+++ b/src/code_gen/genapi.py
@@ -152,8 +152,8 @@ def genapi(
         mod_source
         % (
             "\n    ".join([f"{name}__mod_clear(m, state);" for name in mod_types]),
-            "\n  ".join([f"{name}__mod_types();" for name in mod_types]),
-            "\n  ".join([f"{name}__mod_init(m, state);" for name in mod_types]),
+            "\n  ".join([f"SETUP_TYPES({name})" for name in mod_types]),
+            "\n  ".join([f"ADD_OBJECTS({name})" for name in mod_types]),
         ),
         encoding="utf-8",
     )

--- a/test/_C/test_conditional.py
+++ b/test/_C/test_conditional.py
@@ -1,0 +1,14 @@
+import pytest
+import caterpillar
+
+if caterpillar.native_support():
+    from caterpillar._C import Conditional
+    from caterpillar.py import ctx, pack, unpack, Bytes
+
+    def testc_conditional_init():
+        # simple declarative switch parsing
+        atom = Conditional(
+            Bytes(1),
+            True,
+        )
+        assert atom.condition is True

--- a/test/_C/test_repeated.py
+++ b/test/_C/test_repeated.py
@@ -1,0 +1,78 @@
+import pytest
+import caterpillar
+
+
+if caterpillar.native_support():
+    from caterpillar._C import Repeated
+    from caterpillar.py import uint8, pack, unpack, Bytes, sizeof, typeof
+
+    def testc_repeated_init():
+        atom = Repeated(uint8, 3)
+        assert atom.atom is uint8
+        assert atom.length == 3
+
+    def testc_repeated_pack():
+        raw_data = b"\x01\x02\x03"
+        py_data = [1, 2, 3]
+
+        # The Repeated atom implements the sequence packing and
+        # unpacking without needing a Field instance. However, types
+        # that are not field agnosti, will throw an exception here.
+        atom = Repeated(uint8, 3)
+        with pytest.raises(KeyError):
+            _ = pack(py_data, atom)
+
+        # To temporarily support non-field agnostic types, use the
+        # as_field argument. NOTE: this MAY lead to unintended side
+        # effects.
+        assert pack(py_data, atom, as_field=True) == raw_data
+
+        atom = Repeated(Bytes(2), 3)
+        py_data = [b"ab", b"cd", b"ef"]
+        raw_data = b"".join(py_data)
+        # default struct-like objects should work without any problems
+        assert pack(py_data, atom, as_field=True) == raw_data
+
+        # Prefixed length is supported too
+        atom = Repeated(uint8, slice(uint8, None, 2))
+        py_data = [1, 2, 3]
+        raw_data = b"\x03\x01\x02\x03"
+        assert pack(py_data, atom, as_field=True) == raw_data
+
+        # Context Lambda should work too
+        atom = Repeated(uint8, lambda context: context._root.length)
+        py_data = [1, 2, 3]
+        raw_data = b"\x01\x02\x03"
+        assert pack(py_data, atom, as_field=True, length=3) == raw_data
+
+    def testc_repeated_unpack():
+        py_data = [b"ab", b"cd", b"ef"]
+        raw_data = b"".join(py_data)
+        # The Repeated atom implements the sequence packing and
+        # unpacking without needing a Field instance. However, types
+        # that are not field agnostic, will throw an exception here.
+        atom = Repeated(Bytes(2), 3)
+        assert unpack(atom, raw_data) == py_data
+
+        # To temporarily support non-field agnostic types, use the
+        # as_field argument. NOTE: this MAY lead to unintended side
+        # effects.
+        atom = Repeated(Bytes(2), slice(uint8, None, 2))
+        assert unpack(atom, b"\x03" + raw_data, as_field=True) == py_data
+
+        # Context Lambda should work too
+        atom = Repeated(Bytes(2), lambda context: context._root.length)
+        assert unpack(atom, raw_data, length=3) == py_data
+
+    def testc_repeated_size():
+        atom = Repeated(Bytes(2), 3)
+        assert sizeof(atom) == 6
+
+        # Dynamic length will raise an exception
+        atom = Repeated(Bytes(2), slice(uint8, None, 2))
+        with pytest.raises(ValueError):
+            assert sizeof(atom) == 6
+
+    def testc_repeated_type():
+        atom = Repeated(Bytes(2), 3)
+        assert typeof(atom) == list[bytes]

--- a/test/_C/test_switch.py
+++ b/test/_C/test_switch.py
@@ -1,0 +1,66 @@
+import pytest
+import caterpillar
+import enum
+
+from caterpillar.shared import typeof
+
+
+if caterpillar.native_support():
+    from caterpillar._C import Switch
+    from caterpillar.py import Bytes, String, ctx, pack, unpack
+    from caterpillar.exception import ValidationError
+
+    def testc_switch_init():
+        # simple declarative switch parsing
+        atom = Switch(
+            Bytes(1),
+            {
+                b"a": String(1),
+                b"b": String(2),
+            },
+        )
+        assert atom.atom.length == 1
+        assert len(atom.cases) == 2
+
+    def testc_switch_pack():
+        atom = Switch(
+            ctx._root.target,
+            {
+                b"a": String(1),
+                b"b": String(2),
+            },
+        )
+        assert pack("a", atom, target=b"a") == b"a"
+        assert pack("bb", atom, target=b"b") == b"bb"
+        # will expect two bytes
+        with pytest.raises(ValidationError):
+            assert pack("c", atom, target=b"b")
+
+    def testc_switch_unpack():
+        class SomeType(enum.Enum):
+            A = 1
+            B = 2
+            C = 3
+
+        atom = Switch(
+            ctx._root.target,
+            {
+                SomeType.A: String(1),
+                SomeType.B: String(2),
+            },
+        )
+        assert unpack(atom, b"a", target=SomeType.A) == "a"
+        assert unpack(atom, b"bb", target=SomeType.B) == "bb"
+        # will expect two bytes
+        with pytest.raises(ValueError):
+            assert unpack(atom, b"c", target=SomeType.C)
+
+    def testc_switch_type():
+        atom = Switch(
+            ctx._root.target,
+            {
+                b"a": String(1),
+                b"b": String(2),
+            }
+        )
+        assert typeof(atom) == object | str


### PR DESCRIPTION
+ New index assignment system when generating CAPI code. A running number is now applied instead of a hard coded index.
+ New builtin atoms (CAPI): `Repeated`, `Conditional` and `Switch`
+ Fix incorrect implementation of CpContext_GetRoot
+ Add new shared objects and exception types to the native implementation (`Cp_ContextFactory`, `Cp_ArrayFactory`, `CpExc_Stop` and `Cp_DefaultOption`)